### PR TITLE
Fix broken DOI link

### DIFF
--- a/pwm_HOCOMOCO/human/template/model.yaml
+++ b/pwm_HOCOMOCO/human/template/model.yaml
@@ -7,7 +7,7 @@ info:
   contributors:
       - name: Ziga Avsec
         github: avsecz
-  cite_as: https://doi:10.1093/nar/gkv1249
+  cite_as: https://doi.org/10.1093/nar/gkv1249
   version: 0.1
   doc: >
     '''Simple PWM-scanning model


### PR DESCRIPTION
The `pwm_HOCOMOCO` link at http://kipoi.org/groups/ wasn't working because of the URL formatting.