### PR TITLE
change pinnings for deepTarget

### DIFF
--- a/deepTarget/bio_utils.py
+++ b/deepTarget/bio_utils.py
@@ -20,7 +20,7 @@ import itertools
 import numpy as np
 
 from keras.preprocessing import sequence
-from sklearn.cross_validation import KFold
+from sklearn.model_selection import KFold 
 
 
 # definitions for candiate lists

--- a/deepTarget/dataloader.yaml
+++ b/deepTarget/dataloader.yaml
@@ -18,7 +18,7 @@ defined_as: dataloader.py::dataset
 dependencies:
   conda:
   - biopython>=1.66
-  - scikit-learn>=0.17.1
+  - scikit-learn>=0.18.2
   - theano==0.8.2
   - numpy>=1.12.0
   pip:

--- a/deepTarget/dataloader.yaml
+++ b/deepTarget/dataloader.yaml
@@ -17,7 +17,7 @@ args:
 defined_as: dataloader.py::dataset
 dependencies:
   conda:
-  - biopython==1.66
+  - biopython>=1.66
   - scikit-learn>=0.17.1
   - theano==0.8.2
   - numpy>=1.12.0

--- a/deepTarget/dataloader.yaml
+++ b/deepTarget/dataloader.yaml
@@ -20,7 +20,7 @@ dependencies:
   - biopython==1.66
   - scikit-learn==0.17.1
   - theano==0.8.2
-  - numpy==1.10.4
+  - numpy>=1.12.0
   pip:
   - keras==0.3.3
 info:

--- a/deepTarget/dataloader.yaml
+++ b/deepTarget/dataloader.yaml
@@ -18,7 +18,7 @@ defined_as: dataloader.py::dataset
 dependencies:
   conda:
   - biopython==1.66
-  - scikit-learn==0.17.1
+  - scikit-learn>=0.17.1
   - theano==0.8.2
   - numpy>=1.12.0
   pip:

--- a/deepTarget/model.yaml
+++ b/deepTarget/model.yaml
@@ -15,7 +15,7 @@ defined_as: model.Model
 dependencies:
   conda:
   - theano==0.8.2
-  - numpy==1.10.4
+  - numpy>=1.12.0
   pip:
   - keras==0.3.3
 info:


### PR DESCRIPTION
change pinning of numpy to the minimal version of numpy supported by kipoi (since pandas>=0.21 wants numpy >= 1.12.0)
This also required changes of pinning of the other packages