### PR TITLE
added explicit kipoi dependencies

### DIFF
--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -47,7 +47,7 @@ echo "Installing Kipoi."
 # install kipoi and others from the master branch for now
 pip install git+https://github.com/kipoi/kipoi-utils
 pip install git+https://github.com/kipoi/kipoi-conda
-pip install git+https://github.com/kipoi/kipoi
+pip install git+https://github.com/DerThorsten/kipoi@verbose
 # pip install kipoi
 
 # fi

--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -44,7 +44,9 @@ model_sources:
 # ---
 
 echo "Installing Kipoi."
-# install kipoi from the master branch for now
+# install kipoi and others from the master branch for now
+pip install git+https://github.com/kipoi/kipoi-utils
+pip install git+https://github.com/kipoi/kipoi-conda
 pip install git+https://github.com/kipoi/kipoi
 # pip install kipoi
 

--- a/KipoiSplice/4/model.yaml
+++ b/KipoiSplice/4/model.yaml
@@ -6,6 +6,8 @@ args:
   predict_method: predict_proba
 default_dataloader: .
 dependencies:
+  conda:
+  - h5py
   pip:
   - scikit-learn
   - kipoi

--- a/KipoiSplice/4/model.yaml
+++ b/KipoiSplice/4/model.yaml
@@ -7,7 +7,7 @@ args:
 default_dataloader: .
 dependencies:
   pip:
-  - scikit-learn
+  - scikit-learn # move to pip
 info:
   authors:
   - github: avsecz

--- a/KipoiSplice/4/model.yaml
+++ b/KipoiSplice/4/model.yaml
@@ -7,7 +7,8 @@ args:
 default_dataloader: .
 dependencies:
   pip:
-  - scikit-learn # move to pip
+  - scikit-learn
+  - kipoi
 info:
   authors:
   - github: avsecz

--- a/KipoiSplice/4cons/model.yaml
+++ b/KipoiSplice/4cons/model.yaml
@@ -9,6 +9,7 @@ dependencies:
   pip:
   - scikit-learn
   - kipoi
+  - h5py
 info:
   authors:
   - github: avsecz

--- a/KipoiSplice/4cons/model.yaml
+++ b/KipoiSplice/4cons/model.yaml
@@ -6,10 +6,11 @@ args:
   predict_method: predict_proba
 default_dataloader: .
 dependencies:
+  conda:
+  - h5py
   pip:
   - scikit-learn
   - kipoi
-  - h5py
 info:
   authors:
   - github: avsecz

--- a/KipoiSplice/4cons/model.yaml
+++ b/KipoiSplice/4cons/model.yaml
@@ -8,6 +8,7 @@ default_dataloader: .
 dependencies:
   pip:
   - scikit-learn
+  - kipio # is this really needed?
 info:
   authors:
   - github: avsecz

--- a/KipoiSplice/4cons/model.yaml
+++ b/KipoiSplice/4cons/model.yaml
@@ -8,7 +8,7 @@ default_dataloader: .
 dependencies:
   pip:
   - scikit-learn
-  - kipoi # is this really needed?
+  - kipoi
 info:
   authors:
   - github: avsecz

--- a/KipoiSplice/4cons/model.yaml
+++ b/KipoiSplice/4cons/model.yaml
@@ -8,7 +8,7 @@ default_dataloader: .
 dependencies:
   pip:
   - scikit-learn
-  - kipio # is this really needed?
+  - kipoi # is this really needed?
 info:
   authors:
   - github: avsecz

--- a/tests/test_all_models.py
+++ b/tests/test_all_models.py
@@ -11,9 +11,9 @@ import pytest
 import subprocess
 import kipoi
 import logging
-from kipoi.conda import get_kipoi_bin, env_exists, remove_env
+from kipoi_conda import get_kipoi_bin, env_exists, remove_env
 from kipoi.cli.env import conda_env_name
-from kipoi.utils import list_files_recursively, read_txt
+from kipoi_utils.utils import list_files_recursively, read_txt
 
 
 def models_to_test(src):


### PR DESCRIPTION
kipoiSplice complains about kipoi being not installed:

```
--------------------
14/30 - model: KipoiSplice/4
--------------------
INFO [kipoi.cli.env] Writing environment file: /tmp/kipoi/envfiles/8e68a201
INFO [kipoi.cli.env] Loading model: KipoiSplice/4 description
INFO [kipoi.sources] Update /root/repo/
Already up-to-date.
INFO [kipoi.cli.env] Inferred dataloader name: KipoiSplice/4 from the model.
INFO [kipoi.cli.env] Environment name: test-kipoi-KipoiSplice__4
INFO [kipoi.cli.env] Output env file: /tmp/kipoi/envfiles/8e68a201/test-kipoi-KipoiSplice__4.yaml
WARNING [kipoi.specs] Swapping channel order - putting defaults last. Using pysam bioconda instead of anaconda
INFO [kipoi.cli.env] Done writing the environment file!
INFO [kipoi.cli.env] Creating conda env from file: /tmp/kipoi/envfiles/8e68a201/test-kipoi-KipoiSplice__4.yaml
Traceback (most recent call last):
  File "/opt/conda/bin/kipoi", line 11, in <module>
    load_entry_point('kipoi==0.6.9', 'console_scripts', 'kipoi')()
  File "/opt/conda/lib/python3.6/site-packages/kipoi/__main__.py", line 105, in main
    command_fn(args.command, sys.argv[2:])
  File "/opt/conda/lib/python3.6/site-packages/kipoi/cli/env.py", line 694, in cli_main
    command_fn(args.command, raw_args[1:])
  File "/opt/conda/lib/python3.6/site-packages/kipoi/cli/env.py", line 463, in cli_create
    env_db_entry.cli_path = get_kipoi_bin(env)
  File "/opt/conda/lib/python3.6/site-packages/kipoi_conda/utils.py", line 74, in get_kipoi_bin
    raise ValueError("kipoi is not installed in conda environment: {0}".format(env_name))
ValueError: kipoi is not installed in conda environment: test-kipoi-KipoiSplice__4
ERROR [kipoi.cli.source_test] Model KipoiSplice/4 failed: local variable 'e' referenced before assignment
```
Lets see what happens if we add the explicit dependencies