### PR TITLE
newer version of kipoi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 variables:
   defaults: &defaults
     docker:
-      - image: continuumio/miniconda3:4.3.14
+      - image: continuumio/miniconda3:4.5.12
     working_directory: ~/repo
     environment:
       GIT_LFS_SKIP_SMUDGE: "1"

--- a/DeepSEA/predict/model.yaml
+++ b/DeepSEA/predict/model.yaml
@@ -15,7 +15,6 @@ info:
   name: DeepSEA
   version: 0.94
   license: CC-BY 3.0
-
   doc: >
     This CNN is based on the DeepSEA model from Zhou and Troyanskaya (2015).
     The model has been converted to a pytorch model on a modified version of

--- a/config.yaml
+++ b/config.yaml
@@ -5,4 +5,4 @@ test:
 
 dependencies:
   pip:
-    kipoi>=0.5.9
+    kipoi>=0.6.9


### PR DESCRIPTION
- using recent version of kipoi in dependencies
- minuscule change in model to trigger some builds
- using newer/most recent version of docker container, otherwise one gets `jessie-updates/main amd64 Packages 404 Not Found` from `apt-get install build-essentials`