### PR TITLE
Fixed ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,6 @@ workflows:
              branches:
                only:
                  - master
-                 - fix-ci
                  - test_all
 
   # workflow for testing all the models

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,7 @@ workflows:
              branches:
                only:
                  - master
+                 - fix-ci
                  - test_all
 
   # workflow for testing all the models

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,7 @@ jobs:
       - run:
           name: run tests
           # Use  --clean_env to remove the environment of each model
+          no_output_timeout: 30m
           command: kipoi test-source kipoi --all
       - run:
           name: run tests in common environments


### PR DESCRIPTION
For some reason, SeqVec models are taking longer time than before for downloading the model weights. I used [this trick](https://support.circleci.com/hc/en-us/articles/360045268074-Build-Fails-with-Too-long-with-no-output-exceeded-10m0s-context-deadline-exceeded-) to update the circleci config file.
