### PR TITLE
Increasing timeout again for circleci  

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
       - run:
           name: run tests in common environmnets
           command: kipoi test-source kipoi --git-range master HEAD --common_env
-          no_output_timeout: 15m
+          no_output_timeout: 60m
       - *store_artifacts
 
   # test all models in the repo
@@ -63,7 +63,7 @@ jobs:
       - run:
           name: run tests
           # Use  --clean_env to remove the environment of each model
-          no_output_timeout: 30m
+          no_output_timeout: 60m
           command: kipoi test-source kipoi --all
       - run:
           name: run tests in common environments


### PR DESCRIPTION
In the past I have increased no_output_timeout to 30 minute from default 10 minutes. That did not work for the first time yesterday's nightly tests. I am increasing the timeout to 60 minutes here. Since it  is highly dependent on the respective download speeds and zenodo's fluctuating access speed it is very hard to guarantee that it will work always. Maybe there is a way around it? On the other hand, since we are using the free version of circleci there is no real danger other than the ci getting stuck for an hour.

Source - [Here](https://support.circleci.com/hc/en-us/articles/360045268074-Build-Fails-with-Too-long-with-no-output-exceeded-10m0s-context-deadline-exceeded-)