### PR TITLE
Pin pip version across all model groups

### DIFF
--- a/BPNet-OSKN/model.yaml
+++ b/BPNet-OSKN/model.yaml
@@ -34,18 +34,18 @@ dependencies:
       - bioconda::pysam>=0.14.0
       - bioconda::genomelake==0.1.4
 
-      - pytorch::pytorch  # optional for data-loading
-      - cython
-      - h5py>=2.7.0
-      - numpy
+      - pytorch::pytorch=1.4.0  # optional for data-loading
+      - cython=0.29.22
+      - h5py=2.10.0
+      - numpy=1.19.2
 
-      - pandas>=0.23.0
-      - fastparquet
-      - python-snappy
-
-      - nb_conda
+      - pandas=1.1.5
+      - fastparquet=0.5.0
+      - python-snappy=0.6.0
+      - pip=21.0.1
+      - nb_conda=2.2.1
     pip:
-      - tensorflow>=1.0,<1.15
+      - tensorflow==1.14.0
       - git+https://github.com/kundajelab/DeepExplain.git
       - keras==2.2.4
       - git+https://github.com/kundajelab/bpnet.git@0cb7277b736260f8b4084c9b0c5bd62b9edb5266

--- a/CpGenie/merged/model.yaml
+++ b/CpGenie/merged/model.yaml
@@ -36,11 +36,12 @@ default_dataloader:
     dummy_axis: 1
 dependencies:
   conda:
-    - python=3.6
+    - python=3.6.12
     - h5py=2.10.0
     - tensorflow=1.10.0
     - keras=1.2.2
     - pysam=0.15.3
+    - pip=20.2.4
 schema:
   inputs:
     name: seq

--- a/CpGenie/model-template.yaml
+++ b/CpGenie/model-template.yaml
@@ -48,10 +48,12 @@ default_dataloader:
     dummy_axis: 1
 dependencies:
   conda:
+    - python=3.6.12
     - h5py=2.10.0
     - tensorflow=1.10.0
     - keras=1.2.2
     - pysam=0.15.3
+    - pip=20.2.4
 schema:
   inputs:
     name: seq

--- a/DeepBind/model-template.yaml
+++ b/DeepBind/model-template.yaml
@@ -37,11 +37,13 @@ default_dataloader:
 
 dependencies:
   conda:
+    - python=3.6.12
     - h5py=2.10.0
     - tensorflow=1.4.1
     - keras=2.1.6
     - python=3.6
     - pysam=0.15.3
+    - pip=20.2.4
 schema:
   inputs:
     name: seq

--- a/DeepCpG_DNA/Hou2016_HCC_dna/dataloader.yaml
+++ b/DeepCpG_DNA/Hou2016_HCC_dna/dataloader.yaml
@@ -12,12 +12,11 @@ args:
 defined_as: dataloader.py::SeqDataset
 dependencies:
   conda:
-  - bioconda::genomelake==0.1.4
-  - bioconda::pybedtools
-  - python=3.5
-  - numpy
-  - pandas
-  - cython
+  - bioconda::genomelake=0.1.4
+  - bioconda::pybedtools=0.8.1
+  - python=3.6
+  - numpy=1.19.2
+  - pandas=1.1.3
 info:
   authors:
   - github: avsecz

--- a/DeepCpG_DNA/Hou2016_HCC_dna/model.yaml
+++ b/DeepCpG_DNA/Hou2016_HCC_dna/model.yaml
@@ -11,7 +11,7 @@ args:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6.12
+    - python=3.5
     - h5py=2.10.0
     - pip=20.2.4
   pip:

--- a/DeepCpG_DNA/Hou2016_HCC_dna/model.yaml
+++ b/DeepCpG_DNA/Hou2016_HCC_dna/model.yaml
@@ -11,12 +11,13 @@ args:
 default_dataloader: .
 dependencies:
   conda:
-  - python=3.5
-  - h5py
+    - python=3.6.12
+    - h5py=2.10.0
+    - pip=20.2.4
   pip:
-  - tensorflow==1.4.1
-  - keras==1.2.2
-  - deepcpg==1.0.4
+    - tensorflow==1.10.0
+    - keras==1.2.2
+    - deepcpg==1.0.4
 info:
   authors:
   - github: cangermueller

--- a/DeepCpG_DNA/Hou2016_HCC_dna/model.yaml
+++ b/DeepCpG_DNA/Hou2016_HCC_dna/model.yaml
@@ -11,13 +11,12 @@ args:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.5
+    - python=3.6
     - h5py=2.10.0
     - pip=20.2.4
   pip:
     - tensorflow==1.10.0
     - keras==1.2.2
-    - deepcpg==1.0.4
 info:
   authors:
   - github: cangermueller

--- a/DeepCpG_DNA/Hou2016_HepG2_dna/dataloader.yaml
+++ b/DeepCpG_DNA/Hou2016_HepG2_dna/dataloader.yaml
@@ -12,12 +12,11 @@ args:
 defined_as: dataloader.py::SeqDataset
 dependencies:
   conda:
-  - bioconda::genomelake==0.1.4
-  - bioconda::pybedtools
-  - python=3.5
-  - numpy
-  - pandas
-  - cython
+    - bioconda::genomelake=0.1.4
+    - bioconda::pybedtools=0.8.1
+    - python=3.6
+    - numpy=1.19.2
+    - pandas=1.1.3
 info:
   authors:
   - github: avsecz

--- a/DeepCpG_DNA/Hou2016_HepG2_dna/model.yaml
+++ b/DeepCpG_DNA/Hou2016_HepG2_dna/model.yaml
@@ -10,12 +10,13 @@ args:
 default_dataloader: .
 dependencies:
   conda:
-  - python=3.5
-  - h5py
+    - python=3.6.12
+    - h5py=2.10.0
+    - pip=20.2.4
   pip:
-  - tensorflow==1.4.1
-  - keras==1.2.2
-  - deepcpg==1.0.4
+    - tensorflow==1.10.0
+    - keras==1.2.2
+    - deepcpg==1.0.4
 info:
   authors:
   - github: cangermueller

--- a/DeepCpG_DNA/Hou2016_HepG2_dna/model.yaml
+++ b/DeepCpG_DNA/Hou2016_HepG2_dna/model.yaml
@@ -10,13 +10,12 @@ args:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.5
+    - python=3.6
     - h5py=2.10.0
     - pip=20.2.4
   pip:
     - tensorflow==1.10.0
     - keras==1.2.2
-    - deepcpg==1.0.4
 info:
   authors:
   - github: cangermueller

--- a/DeepCpG_DNA/Hou2016_HepG2_dna/model.yaml
+++ b/DeepCpG_DNA/Hou2016_HepG2_dna/model.yaml
@@ -10,7 +10,7 @@ args:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6.12
+    - python=3.5
     - h5py=2.10.0
     - pip=20.2.4
   pip:

--- a/DeepCpG_DNA/Hou2016_mESC_dna/dataloader.yaml
+++ b/DeepCpG_DNA/Hou2016_mESC_dna/dataloader.yaml
@@ -12,12 +12,11 @@ args:
 defined_as: dataloader.py::SeqDataset
 dependencies:
   conda:
-  - bioconda::genomelake==0.1.4
-  - bioconda::pybedtools
-  - python=3.5
-  - numpy
-  - pandas
-  - cython
+    - bioconda::genomelake=0.1.4
+    - bioconda::pybedtools=0.8.1
+    - python=3.6
+    - numpy=1.19.2
+    - pandas=1.1.3
 info:
   authors:
   - github: avsecz

--- a/DeepCpG_DNA/Hou2016_mESC_dna/model.yaml
+++ b/DeepCpG_DNA/Hou2016_mESC_dna/model.yaml
@@ -10,12 +10,13 @@ args:
 default_dataloader: .
 dependencies:
   conda:
-  - python=3.5
-  - h5py
+    - python=3.6.12
+    - h5py=2.10.0
+    - pip=20.2.4
   pip:
-  - tensorflow==1.4.1
-  - keras==1.2.2
-  - deepcpg==1.0.4
+    - tensorflow==1.10.0
+    - keras==1.2.2
+    - deepcpg==1.0.4
 info:
   authors:
   - github: cangermueller

--- a/DeepCpG_DNA/Hou2016_mESC_dna/model.yaml
+++ b/DeepCpG_DNA/Hou2016_mESC_dna/model.yaml
@@ -10,13 +10,12 @@ args:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.5
+    - python=3.6
     - h5py=2.10.0
     - pip=20.2.4
   pip:
     - tensorflow==1.10.0
     - keras==1.2.2
-    - deepcpg==1.0.4
 info:
   authors:
   - github: cangermueller

--- a/DeepCpG_DNA/Hou2016_mESC_dna/model.yaml
+++ b/DeepCpG_DNA/Hou2016_mESC_dna/model.yaml
@@ -10,7 +10,7 @@ args:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6.12
+    - python=3.5
     - h5py=2.10.0
     - pip=20.2.4
   pip:

--- a/DeepCpG_DNA/Smallwood2014_2i_dna/dataloader.yaml
+++ b/DeepCpG_DNA/Smallwood2014_2i_dna/dataloader.yaml
@@ -12,12 +12,11 @@ args:
 defined_as: dataloader.py::SeqDataset
 dependencies:
   conda:
-  - bioconda::genomelake==0.1.4
-  - bioconda::pybedtools
-  - python=3.5
-  - numpy
-  - pandas
-  - cython
+    - bioconda::genomelake=0.1.4
+    - bioconda::pybedtools=0.8.1
+    - python=3.6
+    - numpy=1.19.2
+    - pandas=1.1.3
 info:
   authors:
   - github: avsecz

--- a/DeepCpG_DNA/Smallwood2014_2i_dna/model.yaml
+++ b/DeepCpG_DNA/Smallwood2014_2i_dna/model.yaml
@@ -10,12 +10,13 @@ args:
 default_dataloader: .
 dependencies:
   conda:
-  - python=3.5
-  - h5py
+    - python=3.6.12
+    - h5py=2.10.0
+    - pip=20.2.4
   pip:
-  - tensorflow==1.4.1
-  - keras==1.2.2
-  - deepcpg==1.0.4
+    - tensorflow==1.10.0
+    - keras==1.2.2
+    - deepcpg==1.0.4
 info:
   authors:
   - github: cangermueller

--- a/DeepCpG_DNA/Smallwood2014_2i_dna/model.yaml
+++ b/DeepCpG_DNA/Smallwood2014_2i_dna/model.yaml
@@ -10,13 +10,12 @@ args:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.5
+    - python=3.6
     - h5py=2.10.0
     - pip=20.2.4
   pip:
     - tensorflow==1.10.0
     - keras==1.2.2
-    - deepcpg==1.0.4
 info:
   authors:
   - github: cangermueller

--- a/DeepCpG_DNA/Smallwood2014_2i_dna/model.yaml
+++ b/DeepCpG_DNA/Smallwood2014_2i_dna/model.yaml
@@ -10,7 +10,7 @@ args:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6.12
+    - python=3.5
     - h5py=2.10.0
     - pip=20.2.4
   pip:

--- a/DeepCpG_DNA/Smallwood2014_serum_dna/dataloader.yaml
+++ b/DeepCpG_DNA/Smallwood2014_serum_dna/dataloader.yaml
@@ -12,12 +12,11 @@ args:
 defined_as: dataloader.py::SeqDataset
 dependencies:
   conda:
-  - bioconda::genomelake==0.1.4
-  - bioconda::pybedtools
-  - python=3.5
-  - numpy
-  - pandas
-  - cython
+    - bioconda::genomelake=0.1.4
+    - bioconda::pybedtools=0.8.1
+    - python=3.6
+    - numpy=1.19.2
+    - pandas=1.1.3
 info:
   authors:
   - github: avsecz

--- a/DeepCpG_DNA/Smallwood2014_serum_dna/model.yaml
+++ b/DeepCpG_DNA/Smallwood2014_serum_dna/model.yaml
@@ -10,12 +10,13 @@ args:
 default_dataloader: .
 dependencies:
   conda:
-  - python=3.5
-  - h5py
+    - python=3.6.12
+    - h5py=2.10.0
+    - pip=20.2.4
   pip:
-  - tensorflow==1.4.1
-  - keras==1.2.2
-  - deepcpg==1.0.4
+    - tensorflow==1.10.0
+    - keras==1.2.2
+    - deepcpg==1.0.4
 info:
   authors:
   - github: cangermueller

--- a/DeepCpG_DNA/Smallwood2014_serum_dna/model.yaml
+++ b/DeepCpG_DNA/Smallwood2014_serum_dna/model.yaml
@@ -10,13 +10,12 @@ args:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.5
+    - python=3.6
     - h5py=2.10.0
     - pip=20.2.4
   pip:
     - tensorflow==1.10.0
     - keras==1.2.2
-    - deepcpg==1.0.4
 info:
   authors:
   - github: cangermueller

--- a/DeepCpG_DNA/Smallwood2014_serum_dna/model.yaml
+++ b/DeepCpG_DNA/Smallwood2014_serum_dna/model.yaml
@@ -10,7 +10,7 @@ args:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6.12
+    - python=3.5
     - h5py=2.10.0
     - pip=20.2.4
   pip:

--- a/DeepCpG_DNA/template/dataloader.yaml
+++ b/DeepCpG_DNA/template/dataloader.yaml
@@ -16,12 +16,11 @@ info:
   doc: Dataloader for the DeepCpG.
 dependencies:
   conda:
-    - bioconda::genomelake==0.1.4
-    - bioconda::pybedtools
-    - python=3.5
-    - numpy
-    - pandas
-    - cython
+    - bioconda::genomelake=0.1.4
+    - bioconda::pybedtools=0.8.1
+    - python=3.6
+    - numpy=1.19.2
+    - pandas=1.1.3
 output_schema:
   inputs:
     dna:

--- a/DeepCpG_DNA/template/dataloader_m_template.yaml
+++ b/DeepCpG_DNA/template/dataloader_m_template.yaml
@@ -21,14 +21,11 @@ info:
   doc: Dataloader + target output for the DeepCpG model.
 dependencies:
   conda:
-    - bioconda::genomelake==0.1.4
-    - bioconda::pybedtools
-    - python=3.5
-    - numpy
-    - pandas
-  pip:
-    - cython
-    - deepcpg==1.0.4
+    - bioconda::genomelake=0.1.4
+    - bioconda::pybedtools=0.8.1
+    - python=3.6
+    - numpy=1.19.2
+    - pandas=1.1.3
 output_schema:
   inputs:
     dna:

--- a/DeepCpG_DNA/template/model_template.yaml
+++ b/DeepCpG_DNA/template/model_template.yaml
@@ -23,7 +23,7 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6.12
+    - python=3.5
     - h5py=2.10.0
     - pip=20.2.4
   pip:

--- a/DeepCpG_DNA/template/model_template.yaml
+++ b/DeepCpG_DNA/template/model_template.yaml
@@ -23,13 +23,12 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.5
+    - python=3.6
     - h5py=2.10.0
     - pip=20.2.4
   pip:
     - tensorflow==1.10.0
     - keras==1.2.2
-    - deepcpg==1.0.4
 schema:
   inputs:
     dna:

--- a/DeepCpG_DNA/template/model_template.yaml
+++ b/DeepCpG_DNA/template/model_template.yaml
@@ -23,10 +23,11 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.5
-    - h5py
+    - python=3.6.12
+    - h5py=2.10.0
+    - pip=20.2.4
   pip:
-    - tensorflow==1.4.1
+    - tensorflow==1.10.0
     - keras==1.2.2
     - deepcpg==1.0.4
 schema:

--- a/DeepSEA/beluga/model.yaml
+++ b/DeepSEA/beluga/model.yaml
@@ -32,8 +32,10 @@ default_dataloader:
 
 dependencies:
   conda:
-    - h5py
-    - pytorch::pytorch-cpu>=1.0.0
+    - python=3.6.12
+    - pip=20.2.4
+    - h5py=2.10.0
+    - pytorch::pytorch-cpu=1.3.1
   pip:
     - kipoiseq
 

--- a/DeepSEA/predict/model.yaml
+++ b/DeepSEA/predict/model.yaml
@@ -45,8 +45,10 @@ default_dataloader:
     dtype: np.float32
 dependencies:
   conda:
-    - h5py
-    - pytorch::pytorch-cpu>=0.2.0
+    - python=3.6.12
+    - h5py=2.10.0
+    - pytorch::pytorch-cpu=1.3.1
+    - pip=20.2.4
   pip:
     - kipoiseq
 schema:

--- a/DeepSEA/variantEffects/model.yaml
+++ b/DeepSEA/variantEffects/model.yaml
@@ -44,8 +44,10 @@ default_dataloader:
     dtype: np.float32
 dependencies:
   conda:
-    - h5py
-    - pytorch::pytorch-cpu>=0.2.0
+    - python=3.6.12
+    - h5py=2.10.0
+    - pytorch::pytorch-cpu=1.3.1
+    - pip=20.2.4
   pip:
     - kipoiseq
 schema:

--- a/Framepool/model.yaml
+++ b/Framepool/model.yaml
@@ -13,6 +13,7 @@ dependencies:
     - tensorflow=1.13.1
     - keras=2.2.4
     - h5py=2.9.0
+    - pip=20.2.4
   pip:
     - kipoi
 

--- a/HAL/model.yaml
+++ b/HAL/model.yaml
@@ -8,6 +8,7 @@ dependencies:
   conda:
     - numpy=1.19.2
     - python=3.6
+    - pip=20.2.4
   pip:
     - arrow==0.17.0
     - attrs==20.2.0

--- a/MMSplice/deltaLogitPSI/model.yaml
+++ b/MMSplice/deltaLogitPSI/model.yaml
@@ -14,6 +14,9 @@ info:
     tags:
         - RNA splicing
 dependencies:
+    conda:
+      - python=3.6.13
+      - pip=21.0.1
     pip:
       - h5py==2.10.0
       - mmsplice==1.0.3

--- a/MMSplice/modularPredictions/model.yaml
+++ b/MMSplice/modularPredictions/model.yaml
@@ -14,9 +14,12 @@ info:
     tags:
         - RNA splicing
 dependencies:
-    pip:
-      - h5py==2.10.0
-      - mmsplice==1.0.3
+  conda:
+    - python=3.6.13
+    - pip=21.0.1
+  pip:
+    - h5py==2.10.0
+    - mmsplice==1.0.3
 schema:
     inputs:
       seq:

--- a/MMSplice/mtsplice/model.yaml
+++ b/MMSplice/mtsplice/model.yaml
@@ -14,6 +14,9 @@ info:
     tags:
         - RNA splicing
 dependencies:
+    conda:
+    - python=3.6.13
+    - pip=21.0.1
     pip:
       - h5py==2.10.0
       - mmsplice==2.0.0

--- a/MMSplice/pathogenicity/model.yaml
+++ b/MMSplice/pathogenicity/model.yaml
@@ -15,9 +15,12 @@ info:
     tags:
         - RNA splicing
 dependencies:
-    pip:
-      - h5py==2.10.0
-      - mmsplice==1.0.3
+  conda:
+    - python=3.6.13
+    - pip=21.0.1
+  pip:
+    - h5py==2.10.0
+    - mmsplice==1.0.3
 schema:
     inputs:
       seq:

--- a/MMSplice/splicingEfficiency/model.yaml
+++ b/MMSplice/splicingEfficiency/model.yaml
@@ -14,9 +14,12 @@ info:
     tags:
         - RNA splicing
 dependencies:
-    pip:
-      - h5py==2.10.0
-      - mmsplice==1.0.3
+  conda:
+    - python=3.6.13
+    - pip=21.0.1
+  pip:
+    - h5py==2.10.0
+    - mmsplice==1.0.3
 schema:
     inputs:
       seq:

--- a/MaxEntScan/dataloader.yaml
+++ b/MaxEntScan/dataloader.yaml
@@ -21,6 +21,7 @@ args:
 defined_as: dataloader.py::SplicingMaxEntDatasetSpec
 dependencies:
   conda:
+  - pip=20.2.4
   - pysam=0.15.2
   - python=3.5.6
 info:

--- a/MaxEntScan/model-template.yaml
+++ b/MaxEntScan/model-template.yaml
@@ -27,6 +27,7 @@ info:
         - RNA splicing
 dependencies:
     conda:
+      - pip=20.2.4
       - bioconda::maxentpy=0.0.1
 schema:
     inputs:

--- a/MaxEntScan/model-template.yaml
+++ b/MaxEntScan/model-template.yaml
@@ -27,7 +27,7 @@ info:
         - RNA splicing
 dependencies:
     conda:
-      - bioconda::maxentpy
+      - bioconda::maxentpy=0.0.1
 schema:
     inputs:
         name: seq

--- a/Optimus_5Prime/dataloader.yaml
+++ b/Optimus_5Prime/dataloader.yaml
@@ -19,11 +19,13 @@ defined_as: dataloader.py::FixedSeq5UtrDl
 
 dependencies:
   conda:
-    - bioconda::pybedtools
+    - python=3.6
+    - pip=20.2.4
+    - bioconda::pybedtools=0.8.1
   pip:
     - kipoi
     - kipoiseq
-    - gffutils
+    - gffutils==0.10.1
 
 info:
   authors:

--- a/Optimus_5Prime/model.yaml
+++ b/Optimus_5Prime/model.yaml
@@ -11,8 +11,10 @@ default_dataloader: .
 
 dependencies:
   conda:
-  - tensorflow>=1.0.0
-  - keras>=2.0.4
+  - tensorflow=1.4.1
+  - keras=2.1.6
+  - python=3.6
+  - pip=20.2.4
 
 info:
   authors:

--- a/SiSp/model.yaml
+++ b/SiSp/model.yaml
@@ -12,8 +12,9 @@ default_dataloader: .
 dependencies:
   conda:
   - python=3.6
-  - numpy==1.17.4
-  - pandas==0.24.2
+  - numpy=1.17.4
+  - pandas=0.24.2
+  - pip=20.2.4
   pip:
   - keras==2.1.6
   - tensorflow==1.4.1

--- a/deepTarget/model.yaml
+++ b/deepTarget/model.yaml
@@ -14,10 +14,10 @@ args:
 defined_as: model.Model
 dependencies:
   conda:
-  - python
-  - theano
-  - numpy<=1.12.0
-  - pip
+  - python=3.6.13
+  - theano=1.0.4
+  - numpy=1.11.3
+  - pip=21.0.1
   pip:
   - keras==0.3.3
 info:

--- a/labranchor/model.yaml
+++ b/labranchor/model.yaml
@@ -8,8 +8,9 @@ args:
 default_dataloader: .
 dependencies:
   conda:
-  - pip
-  - bioconda::pysam
+  - pip=20.2.4
+  - python=3.6
+  - bioconda::pysam=0.15.3
   pip:
   - tensorflow==1.4.1
   - keras==2.1.6


### PR DESCRIPTION
Yesterday's nightly test failed due to some upgrade in conda's pip. To be fair, conda continued to give warnings for unpinned pip version. Somehow it broke everything only yesterday (most likely something changed in conda finally). I have now pinned pip version across all of the models. I used the pip version from the working docker images for the respective model groups. 