### PR TITLE
Attempting to add seqvec back to ci

### DIFF
--- a/SeqVec/test_subset.txt
+++ b/SeqVec/test_subset.txt
@@ -1,0 +1,2 @@
+embedding
+structure


### PR DESCRIPTION
Closes: #251 

Somehow, separating CI job into 4 different jobs made SeqVec environments work again during my testing with #253.
For now, adding them back. I will monitor it this week and will reopen this issue if necessary.