### PR TITLE
Improved aparent dependencies

### DIFF
--- a/APARENT/site_probabilities/dataloader.yaml
+++ b/APARENT/site_probabilities/dataloader.yaml
@@ -21,6 +21,7 @@ dependencies:
     - bioconda
     - defaults
   conda:
+    - python=3.9
     - bioconda::kipoi
 #    - bioconda::kipoiseq
     - bioconda::cyvcf2

--- a/APARENT/site_probabilities/model.yaml
+++ b/APARENT/site_probabilities/model.yaml
@@ -63,3 +63,9 @@ schema:
       shape: (205, )
       doc: >
         Predicts logit probability of having a PolyA cut site for each position in the specified DNA range
+
+test:
+  expect:
+    url: https://zenodo.org/record/5511940/files/APARENT.site_probabilities.predictions.hdf5?download=1
+    md5: 1adb12be84240ffb7d7ca556eeb19e01
+        

--- a/APARENT/site_probabilities/model.yaml
+++ b/APARENT/site_probabilities/model.yaml
@@ -12,6 +12,7 @@ dependencies:
     - bioconda
     - defaults
   conda:
+  - python=3.9
   - tensorflow
   - keras>=2.0.4,<3
 

--- a/APARENT/site_probabilities/model.yaml
+++ b/APARENT/site_probabilities/model.yaml
@@ -12,7 +12,7 @@ dependencies:
     - bioconda
     - defaults
   conda:
-  - tensorflow>=1,<2
+  - tensorflow
   - keras>=2.0.4,<3
 
 info:

--- a/APARENT/veff/dataloader.yaml
+++ b/APARENT/veff/dataloader.yaml
@@ -42,6 +42,7 @@ dependencies:
     - bioconda
     - defaults
   conda:
+    - python=3.9
     - bioconda::kipoi
 #    - bioconda::kipoiseq
     - bioconda::cyvcf2

--- a/APARENT/veff/dataloader.yaml
+++ b/APARENT/veff/dataloader.yaml
@@ -42,7 +42,7 @@ dependencies:
     - bioconda
     - defaults
   conda:
-    - python=3.9
+    - python=3.7
     - bioconda::kipoi
 #    - bioconda::kipoiseq
     - bioconda::cyvcf2

--- a/APARENT/veff/dataloader.yaml
+++ b/APARENT/veff/dataloader.yaml
@@ -42,7 +42,7 @@ dependencies:
     - bioconda
     - defaults
   conda:
-    - python
+    - python=3.6
     - bioconda::kipoi
 #    - bioconda::kipoiseq
     - bioconda::cyvcf2

--- a/APARENT/veff/dataloader.yaml
+++ b/APARENT/veff/dataloader.yaml
@@ -42,7 +42,7 @@ dependencies:
     - bioconda
     - defaults
   conda:
-    - python=3.7
+    - python
     - bioconda::kipoi
 #    - bioconda::kipoiseq
     - bioconda::cyvcf2

--- a/APARENT/veff/model.yaml
+++ b/APARENT/veff/model.yaml
@@ -12,7 +12,8 @@ dependencies:
     - bioconda
     - defaults
   conda:
-  - tensorflow>=1,<2
+  - python=3.9
+  - tensorflow
   - keras>=2.0.4,<3
   - numpy
   - scipy

--- a/APARENT/veff/model.yaml
+++ b/APARENT/veff/model.yaml
@@ -12,8 +12,8 @@ dependencies:
     - bioconda
     - defaults
   conda:
-  - python=3.9
-  - tensorflow
+  - python=3.7
+  - tensorflow>=1,<2
   - keras>=2.0.4,<3
   - numpy
   - scipy
@@ -67,3 +67,8 @@ schema:
       shape: (205, )
       doc: >
         Predicts logit percentage difference to reference of having a PolyA cut site for each position in the specified DNA range
+
+test:
+  expect:
+    url: https://zenodo.org/record/5512004/files/APARENT.veff.predictions.hdf5?download=1
+    md5: f70ae0b9ec5f7bdd917d718b19a9e83b

--- a/APARENT/veff/model.yaml
+++ b/APARENT/veff/model.yaml
@@ -12,8 +12,8 @@ dependencies:
     - bioconda
     - defaults
   conda:
-  - python=3.9
-  - tensorflow
+  - python=3.6
+  - tensorflow=1.13
   - keras>=2.0.4,<3
   - numpy
   - scipy

--- a/APARENT/veff/model.yaml
+++ b/APARENT/veff/model.yaml
@@ -12,8 +12,8 @@ dependencies:
     - bioconda
     - defaults
   conda:
-  - python=3.7
-  - tensorflow>=1,<2
+  - python=3.9
+  - tensorflow
   - keras>=2.0.4,<3
   - numpy
   - scipy
@@ -67,8 +67,3 @@ schema:
       shape: (205, )
       doc: >
         Predicts logit percentage difference to reference of having a PolyA cut site for each position in the specified DNA range
-
-test:
-  expect:
-    url: https://zenodo.org/record/5512004/files/APARENT.veff.predictions.hdf5?download=1
-    md5: f70ae0b9ec5f7bdd917d718b19a9e83b


### PR DESCRIPTION
APARENT/site_probabilities is the first model to be using python 3.9 in the model repo. I have also added tests for APARENT/site_probabilities.