### PR TITLE
Updating preprocessing-variant-effects to reflect the current status in kipoi-veff2 intead of kipoi-veff

### DIFF
--- a/CpGenie/merged/model.yaml
+++ b/CpGenie/merged/model.yaml
@@ -57,10 +57,10 @@ schema:
     doc: Predicted methylated probability for different CpGenie models
     column_labels:
       - models.txt
-postprocessing:
-    variant_effects:
-      seq_input:
-        - seq
+# postprocessing:
+#     variant_effects:
+#       seq_input:
+#         - seq
 
 test:
   expect:

--- a/CpGenie/model-template.yaml
+++ b/CpGenie/model-template.yaml
@@ -68,16 +68,16 @@ schema:
     column_labels:
             - methylation_prob
             - unmethylation_prob
-postprocessing:
-    variant_effects:
-      seq_input:
-        - seq
-      use_rc: True
-      scoring_functions:
-        - type: diff
-          default: true
-        - type: logit
-          default: true
+# postprocessing:
+#     variant_effects:
+#       seq_input:
+#         - seq
+#       use_rc: True
+#       scoring_functions:
+#         - type: diff
+#           default: true
+#         - type: logit
+#           default: true
 {% if model == 'GM19239_ENCSR000DGH' %}
 test:
   expect:

--- a/DeepCpG_DNA/Hou2016_HCC_dna/dataloader.yaml
+++ b/DeepCpG_DNA/Hou2016_HCC_dna/dataloader.yaml
@@ -35,8 +35,8 @@ output_schema:
     ranges:
       doc: Ranges describing inputs.seq
       type: GenomicRanges
-postprocessing:
-  variant_effects:
-    bed_input:
-    - intervals_file
+# postprocessing:
+  # variant_effects:
+  #   bed_input:
+  #   - intervals_file
 type: Dataset

--- a/DeepCpG_DNA/Hou2016_HCC_dna/model.yaml
+++ b/DeepCpG_DNA/Hou2016_HCC_dna/model.yaml
@@ -40,11 +40,11 @@ info:
   trained_on: scBS-seq and scRRBS-seq datasets, https://genomebiology.biomedcentral.com/articles/10.1186/s13059-017-1189-z#Sec7
   training_procedure: Described in https://genomebiology.biomedcentral.com/articles/10.1186/s13059-017-1189-z#Sec7
   version: 1.0.4
-postprocessing:
-  variant_effects:
-    seq_input:
-    - dna
-    use_rc: true
+# postprocessing:
+#   variant_effects:
+#     seq_input:
+#     - dna
+#     use_rc: true
 schema:
   inputs:
     dna:

--- a/DeepCpG_DNA/Hou2016_HepG2_dna/dataloader.yaml
+++ b/DeepCpG_DNA/Hou2016_HepG2_dna/dataloader.yaml
@@ -35,8 +35,8 @@ output_schema:
     ranges:
       doc: Ranges describing inputs.seq
       type: GenomicRanges
-postprocessing:
-  variant_effects:
-    bed_input:
-    - intervals_file
+# postprocessing:
+#   variant_effects:
+#     bed_input:
+#     - intervals_file
 type: Dataset

--- a/DeepCpG_DNA/Hou2016_HepG2_dna/model.yaml
+++ b/DeepCpG_DNA/Hou2016_HepG2_dna/model.yaml
@@ -39,11 +39,11 @@ info:
   trained_on: scBS-seq and scRRBS-seq datasets, https://genomebiology.biomedcentral.com/articles/10.1186/s13059-017-1189-z#Sec7
   training_procedure: Described in https://genomebiology.biomedcentral.com/articles/10.1186/s13059-017-1189-z#Sec7
   version: 1.0.4
-postprocessing:
-  variant_effects:
-    seq_input:
-    - dna
-    use_rc: true
+# postprocessing:
+#   variant_effects:
+#     seq_input:
+#     - dna
+#     use_rc: true
 schema:
   inputs:
     dna:

--- a/DeepCpG_DNA/Hou2016_mESC_dna/dataloader.yaml
+++ b/DeepCpG_DNA/Hou2016_mESC_dna/dataloader.yaml
@@ -35,8 +35,8 @@ output_schema:
     ranges:
       doc: Ranges describing inputs.seq
       type: GenomicRanges
-postprocessing:
-  variant_effects:
-    bed_input:
-    - intervals_file
+# postprocessing:
+#   variant_effects:
+#     bed_input:
+#     - intervals_file
 type: Dataset

--- a/DeepCpG_DNA/Hou2016_mESC_dna/model.yaml
+++ b/DeepCpG_DNA/Hou2016_mESC_dna/model.yaml
@@ -39,11 +39,11 @@ info:
   trained_on: scBS-seq and scRRBS-seq datasets, https://genomebiology.biomedcentral.com/articles/10.1186/s13059-017-1189-z#Sec7
   training_procedure: Described in https://genomebiology.biomedcentral.com/articles/10.1186/s13059-017-1189-z#Sec7
   version: 1.0.4
-postprocessing:
-  variant_effects:
-    seq_input:
-    - seq
-    use_rc: true
+# postprocessing:
+#   variant_effects:
+#     seq_input:
+#     - seq
+#     use_rc: true
 schema:
   inputs:
     dna:

--- a/DeepCpG_DNA/Smallwood2014_2i_dna/dataloader.yaml
+++ b/DeepCpG_DNA/Smallwood2014_2i_dna/dataloader.yaml
@@ -35,8 +35,8 @@ output_schema:
     ranges:
       doc: Ranges describing inputs.seq
       type: GenomicRanges
-postprocessing:
-  variant_effects:
-    bed_input:
-    - intervals_file
+# postprocessing:
+#   variant_effects:
+#     bed_input:
+#     - intervals_file
 type: Dataset

--- a/DeepCpG_DNA/Smallwood2014_serum_dna/dataloader.yaml
+++ b/DeepCpG_DNA/Smallwood2014_serum_dna/dataloader.yaml
@@ -35,8 +35,8 @@ output_schema:
     ranges:
       doc: Ranges describing inputs.seq
       type: GenomicRanges
-postprocessing:
-  variant_effects:
-    bed_input:
-    - intervals_file
+# postprocessing:
+#   variant_effects:
+#     bed_input:
+#     - intervals_file
 type: Dataset

--- a/DeepCpG_DNA/Smallwood2014_serum_dna/model.yaml
+++ b/DeepCpG_DNA/Smallwood2014_serum_dna/model.yaml
@@ -39,11 +39,11 @@ info:
   trained_on: scBS-seq and scRRBS-seq datasets, https://genomebiology.biomedcentral.com/articles/10.1186/s13059-017-1189-z#Sec7
   training_procedure: Described in https://genomebiology.biomedcentral.com/articles/10.1186/s13059-017-1189-z#Sec7
   version: 1.0.4
-postprocessing:
-  variant_effects:
-    seq_input:
-    - dna
-    use_rc: true
+# postprocessing:
+#   variant_effects:
+#     seq_input:
+#     - dna
+#     use_rc: true
 schema:
   inputs:
     dna:

--- a/DeepCpG_DNA/template/dataloader.yaml
+++ b/DeepCpG_DNA/template/dataloader.yaml
@@ -32,7 +32,7 @@ output_schema:
     ranges:
       type: GenomicRanges
       doc: Ranges describing inputs.seq
-postprocessing:
-    variant_effects:
-      bed_input:
-        - intervals_file
+# postprocessing:
+#     variant_effects:
+#       bed_input:
+#         - intervals_file

--- a/DeepCpG_DNA/template/model_template.yaml
+++ b/DeepCpG_DNA/template/model_template.yaml
@@ -36,8 +36,8 @@ schema:
       shape: (1001, 4)
       special_type: DNASeq
   targets:
-postprocessing:
-    variant_effects:
-      seq_input:
-        - seq
-      use_rc: True
+# postprocessing:
+#     variant_effects:
+#       seq_input:
+#         - seq
+#       use_rc: True

--- a/DeepSEA/predict/model.yaml
+++ b/DeepSEA/predict/model.yaml
@@ -65,7 +65,10 @@ schema:
     doc: Probability of a specific epigentic feature
     column_labels:
       - ../predictor_names.txt
-
+postprocessing:
+  variant_effects:
+    seq_input:
+      - seq
 test:
   expect:
     url: https://s3.eu-central-1.amazonaws.com/kipoi-models/predictions/14f9bf4b49e21c7b31e8f6d6b9fc69ed88e25f43/DeepSEA/predict/predictions.h5

--- a/HAL/model.yaml
+++ b/HAL/model.yaml
@@ -59,12 +59,12 @@ info:
   - RNA splicing
   trained_on: MPRA data of 2M synthetic alternatively spliced mini-genes. Data was split into training and test sets (90%/10% split).
   training_procedure: Described in http://www.cell.com/cms/attachment/2057151419/2061575818/mmc1.pdf
-postprocessing:
-  variant_effects:
-    scoring_functions:
-    - type: diff
-    seq_input:
-    - seq
+# postprocessing:
+#   variant_effects:
+#     scoring_functions:
+#     - type: diff
+#     seq_input:
+#     - seq
 schema:
   inputs:
     doc: K-mer counts

--- a/MPRA-DragoNN/ConvModel/model.yaml
+++ b/MPRA-DragoNN/ConvModel/model.yaml
@@ -40,6 +40,10 @@ dependencies:
       - keras==2.3.1
       - tensorflow==1.14.0
 
+postprocessing:
+  variant_effects:
+    seq_input:
+      - seq
 schema:  # Model schema. The schema defintion is essential for kipoi plug-ins to work.
     inputs:  # input = single numpy array
         shape: (145,4)  # array shape of a single sample (omitting the batch dimension)

--- a/MPRA-DragoNN/DeepFactorizedModel/model.yaml
+++ b/MPRA-DragoNN/DeepFactorizedModel/model.yaml
@@ -39,7 +39,10 @@ dependencies:
     pip:   # install via pip
       - keras==2.3.1
       - tensorflow==1.14.0
-
+postprocessing:
+  variant_effects:
+    seq_input:
+      - seq
 schema:  # Model schema. The schema defintion is essential for kipoi plug-ins to work.
     inputs:  # input = single numpy array
         shape: (145,4)  # array shape of a single sample (omitting the batch dimension)

--- a/MaxEntScan/model-template.yaml
+++ b/MaxEntScan/model-template.yaml
@@ -39,10 +39,10 @@ schema:
         name: psi
         shape: (1, )
         doc: "Predicted psi"
-postprocessing:
-    variant_effects:
-      seq_input:
-        - seq
+# postprocessing:
+#     variant_effects:
+#       seq_input:
+#         - seq
 test:
   expect:
     url: {{ test_expect_url }}

--- a/Optimus_5Prime/model.yaml
+++ b/Optimus_5Prime/model.yaml
@@ -42,10 +42,10 @@ schema:
     doc: Predicted mean ribosome load
     shape: (1, )
 
-postprocessing:
-  variant_effects:
-    seq_input:
-      - seq
+# postprocessing:
+#   variant_effects:
+#     seq_input:
+#       - seq
 
 test:
   expect:

--- a/labranchor/model.yaml
+++ b/labranchor/model.yaml
@@ -35,13 +35,13 @@ info:
   trained_on: "High confidence set of branchpoints reported by Mercer et. al. 2015. Chromosome 1 was used for testing, chromosomes 2, 3, 4 for model selection and the remaining data were used for model training."
   tags:
   - RNA splicing
-postprocessing:
-  variant_effects:
-    scoring_functions:
-    - type: diff
-    - type: logit
-    seq_input:
-    - bidirectional_1_input
+# postprocessing:
+#   variant_effects:
+#     scoring_functions:
+#     - type: diff
+#     - type: logit
+#     seq_input:
+#     - bidirectional_1_input
 schema:
   inputs:
     bidirectional_1_input:

--- a/lsgkm-SVM/model-template.yaml
+++ b/lsgkm-SVM/model-template.yaml
@@ -71,13 +71,13 @@ schema:
         name: lsgkmsvm_scr
         shape: (1, )
         doc: "lsgkm-SVM score"
-postprocessing:
-    variant_effects:
-      seq_input:
-        - seq
-      use_rc: true
-      scoring_functions:
-          - type: diff
+# postprocessing:
+#     variant_effects:
+#       seq_input:
+#         - seq
+#       use_rc: true
+#       scoring_functions:
+#           - type: diff
 {% if model == 'Tfbs/Nanogsc33759/H1hesc/Haib_V0416102' %}
 test:
   expect:

--- a/rbp_eclip/dataloader-template.yaml
+++ b/rbp_eclip/dataloader-template.yaml
@@ -102,7 +102,7 @@ output_schema:
     doc: Measured binding strength
     shape: (1, )
 
-postprocessing:
-  variant_effects:
-    bed_input:
-    - intervals_file
+# postprocessing:
+#   variant_effects:
+#     bed_input:
+#     - intervals_file

--- a/rbp_eclip/model-template.yaml
+++ b/rbp_eclip/model-template.yaml
@@ -71,14 +71,14 @@ schema:
         shape: (1, )
         doc: Predicted binding strength
 
-postprocessing:
-    variant_effects:
-      seq_input:
-        - seq
-      use_rc: true
-      scoring_functions:
-        - type: diff
-        - type: logit
+# postprocessing:
+#     variant_effects:
+#       seq_input:
+#         - seq
+#       use_rc: true
+#       scoring_functions:
+#         - type: diff
+#         - type: logit
 {% if model == 'AARS' %}
 test:
   expect:


### PR DESCRIPTION
For now, I just commented out the existing fields but perhaps we should delete this field altogether from model.yaml and update website repo to use this information directly from kipoi-veff2. If yes, we should also revert https://github.com/kipoi/kipoi/pull/626. Thoughts?  

Also what about MMSPlice?