### PR TITLE
Fixed ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,7 @@ jobs:
       - run:
           name: run tests
           command: kipoi test-source kipoi --git-range master HEAD --verbose
+          no_output_timeout: 60m
       - run:
           name: run tests in common environmnets
           command: kipoi test-source kipoi --git-range master HEAD --common_env

--- a/HAL/model.yaml
+++ b/HAL/model.yaml
@@ -40,7 +40,7 @@ dependencies:
     - tinydb==4.2.0
     - tqdm==4.51.0
     - urllib3==1.25.11
-    - kipoi
+    - kipoi==0.6.35
     - kipoi-conda
     - kipoi-utils
 info:
@@ -59,6 +59,12 @@ info:
   - RNA splicing
   trained_on: MPRA data of 2M synthetic alternatively spliced mini-genes. Data was split into training and test sets (90%/10% split).
   training_procedure: Described in http://www.cell.com/cms/attachment/2057151419/2061575818/mmc1.pdf
+postprocessing:
+  variant_effects:
+    scoring_functions:
+    - type: diff
+    seq_input:
+    - seq
 schema:
   inputs:
     doc: K-mer counts

--- a/KipoiSplice/4/model.yaml
+++ b/KipoiSplice/4/model.yaml
@@ -35,7 +35,6 @@ schema:
       Pathogenicity score. 0th index represents the probability of being benign
       and 1st index represents the probability for being pathogenic.
     shape: (2, )
-
 test:
   expect:
     url: https://s3.eu-central-1.amazonaws.com/kipoi-models/predictions/14f9bf4b49e21c7b31e8f6d6b9fc69ed88e25f43/KipoiSplice/4/predictions.h5

--- a/KipoiSplice/4cons/model.yaml
+++ b/KipoiSplice/4cons/model.yaml
@@ -35,7 +35,6 @@ schema:
       Pathogenicity score. 0th index represents the probability of being benign
       and 1st index represents the probability for being pathogenic.
     shape: (1, )
-
 test:
   expect:
     url: https://s3.eu-central-1.amazonaws.com/kipoi-models/predictions/14f9bf4b49e21c7b31e8f6d6b9fc69ed88e25f43/KipoiSplice/4cons/predictions.h5

--- a/MaxEntScan/model-template.yaml
+++ b/MaxEntScan/model-template.yaml
@@ -29,6 +29,8 @@ dependencies:
     conda:
       - pip=20.2.4
       - bioconda::maxentpy=0.0.1
+    pip:
+      - kipoi==0.6.35
 schema:
     inputs:
         name: seq
@@ -39,6 +41,10 @@ schema:
         name: psi
         shape: (1, )
         doc: "Predicted psi"
+postprocessing:
+  variant_effects:
+    seq_input:
+      - seq
 test:
   expect:
     url: {{ test_expect_url }}

--- a/labranchor/dataloader.yaml
+++ b/labranchor/dataloader.yaml
@@ -15,7 +15,7 @@ args:
 defined_as: dataloader.py::BranchPointDataset
 dependencies:
   conda:
-  - python==3.6
+  - python=3.6
   pip:
   - pysam
   - numpy

--- a/labranchor/model.yaml
+++ b/labranchor/model.yaml
@@ -15,6 +15,7 @@ dependencies:
   - tensorflow==1.4.1
   - keras==2.1.6
   - h5py==2.9.0
+  - kipoi==0.6.35
 info:
   authors:
   - github: jpaggi
@@ -35,6 +36,13 @@ info:
   trained_on: "High confidence set of branchpoints reported by Mercer et. al. 2015. Chromosome 1 was used for testing, chromosomes 2, 3, 4 for model selection and the remaining data were used for model training."
   tags:
   - RNA splicing
+postprocessing:
+  variant_effects:
+    scoring_functions:
+    - type: diff
+    - type: logit
+    seq_input:
+    - bidirectional_1_input
 schema:
   inputs:
     bidirectional_1_input:


### PR DESCRIPTION
I kept postprocessing field in HAL, MaxEntScan and labranchor as is since otherwise kipoisplice tests fail. I pinned kipoi versions in them for future.