### PR TITLE
Adding postprocessing back to maintain compatibiliy with kipoi-veff

### DIFF
--- a/DeepSEA/beluga/model.yaml
+++ b/DeepSEA/beluga/model.yaml
@@ -38,6 +38,7 @@ dependencies:
     - pytorch::pytorch-cpu=1.3.1
     - cython=0.29.23
   pip:
+    - kipoi<=0.6.35
     - kipoiseq
 
 schema:
@@ -54,6 +55,16 @@ schema:
     column_labels:
       - predictor_names.txt
 
+postprocessing:
+     variant_effects:
+       seq_input:
+         - seq
+       use_rc: true
+       scoring_functions:
+         - type: diff
+           default: true
+         - type: logit
+           default: true
 
 test:
  expect:

--- a/DeepSEA/variantEffects/model.yaml
+++ b/DeepSEA/variantEffects/model.yaml
@@ -50,6 +50,7 @@ dependencies:
     - pip=20.2.4
     - cython=0.29.23
   pip:
+    - kipoi<=0.6.35
     - kipoiseq
 schema:
   inputs:
@@ -64,6 +65,16 @@ schema:
     doc: Probability of a specific epigentic feature
     column_labels:
       - ../predictor_names.txt
+postprocessing:
+     variant_effects:
+       seq_input:
+         - seq
+       use_rc: true
+       scoring_functions:
+         - type: diff
+           default: true
+         - type: logit
+           default: true
 test:
   expect:
     url: https://s3.eu-central-1.amazonaws.com/kipoi-models/predictions/14f9bf4b49e21c7b31e8f6d6b9fc69ed88e25f43/DeepSEA/variantEffects/predictions.h5


### PR DESCRIPTION
We need to find a way to make kipoi-veff use an earlier version of models repository to ensure proper backward compatibility. As far as I can see there is no easy way to do that. For now, I am adding back the postprocessing bit of deepsea models.
 