### PR TITLE
Fix APARENT/site_probabilities output labels

### DIFF
--- a/APARENT/site_probabilities/model.py
+++ b/APARENT/site_probabilities/model.py
@@ -18,14 +18,14 @@ class APARENTModel(BaseModel):
 
         _, pred = self.model.predict_on_batch([input_1, input_2, input_3])
 
-        site_probs = pred[:, 1:]
-        polya_prob = pred[:, 0]
-        return site_probs, polya_prob
+        site_props = pred[:, :-1]
+        distal_prop = pred[:, -1]
+        return site_props, distal_prop
 
     def predict_on_batch(self, inputs):
-        site_probs, polya_prob = self._predict(inputs)
+        site_props, distal_prop = self._predict(inputs)
 
         return {
-            "logit_polya_prob": polya_prob,
-            "logit_site_probs": site_probs,
+            "distal_prop": distal_prop,
+            "site_props": site_props,
         }

--- a/APARENT/site_probabilities/model.yaml
+++ b/APARENT/site_probabilities/model.yaml
@@ -53,19 +53,19 @@ schema:
   targets:
     doc: >
       Predicts 206 features:
-      1 prediction for % proximal isoform + 205 predictions for % cleavage at each position
+      1 prediction for % distal cleavage + 205 predictions for % cleavage at each position
     shape: (206, )
-    logit_polya_prob:
+    distal_prop:
       shape: (1, )
       doc: >
-        Predicts logit probability of having a PolyA cut site in the specified DNA range
-    logit_site_probs:
+        Predicts proportion of cleavage occuring outside of the specified DNA range
+    site_props:
       shape: (205, )
       doc: >
-        Predicts logit probability of having a PolyA cut site for each position in the specified DNA range
+        Predicts proportion of cleavage occuring at each position in the specified DNA range
 
 test:
   expect:
     url: https://zenodo.org/record/5511940/files/APARENT.site_probabilities.predictions.hdf5?download=1
     md5: 1adb12be84240ffb7d7ca556eeb19e01
-        
+


### PR DESCRIPTION
From the APARENT paper [methods section](https://www.sciencedirect.com/science/article/pii/S0092867419304982#sec3.4.4.1) on the cleavage model:

> The 186 first Softmax probabilities are trained to predict the cleavage proportions of the 186 nucleotides in the input sequence. The 187-th probability predicts the remaining proportion of polyadenylation outside the sequence window (i.e., the distal isoform).

The model used by Kipoi is an updated one with 205bp but should be the same in terms of output arrangement.

I'm not sure if the tests also have to be updated, but I don't know how to do that.