### PR TITLE
Fixed ci and added conda-libmamba-solver

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,6 +242,7 @@ workflows:
                only:
                  - master
                  - test_all
+                 - add-update-conda
        - test_all_models_singularity:
            matrix:
              parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,14 @@ variables:
         sudo ln -s ~/miniconda3/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
         echo ". ~/miniconda3/etc/profile.d/conda.sh" >> $BASH_ENV && \
         echo "conda activate base" >> $BASH_ENV
+  update_conda: &update_conda
+    run:
+      name: Update conda
+      command: conda update -n base conda
+  install_mamba_solver: &install_mamba_solver
+    run:
+      name: Install mamba solver (experimental)
+      command: conda install -n base conda-libmamba-solver
   install_sys_deps: &install_sys_deps
     run:
       name: install build-essential
@@ -84,7 +92,9 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - *install_conda   
+      - *install_conda
+      - *update_conda   
+      - *install_mamba_solver
       # - *install_sys_deps
       - *install_gitlfs
       - *install_additional_pkgs
@@ -106,7 +116,9 @@ jobs:
     steps:
       - checkout
       - *install_apptainer
-      - *install_conda   
+      - *install_conda
+      - *update_conda   
+      - *install_mamba_solver
       # - *install_sys_deps
       - *install_gitlfs
       - *install_additional_pkgs
@@ -128,7 +140,9 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - *install_conda   
+      - *install_conda 
+      - *update_conda
+      - *install_mamba_solver
       # - *install_sys_deps
       - *install_gitlfs
       - *install_additional_pkgs
@@ -152,7 +166,9 @@ jobs:
     steps:
       - checkout
       - *install_apptainer
-      - *install_conda   
+      - *install_conda
+      - *update_conda   
+      - *install_mamba_solver
       # - *install_sys_deps
       - *install_gitlfs
       - *install_additional_pkgs
@@ -170,7 +186,9 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - *install_conda   
+      - *install_conda 
+      - *update_conda  
+      - *install_mamba_solver
       # - *install_sys_deps
       - *install_gitlfs
       - *install_additional_pkgs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,7 +242,6 @@ workflows:
                only:
                  - master
                  - test_all
-                 - add-update-conda
        - test_all_models_singularity:
            matrix:
              parameters:

--- a/rbp_eclip/dataloader-template.yaml
+++ b/rbp_eclip/dataloader-template.yaml
@@ -46,12 +46,12 @@ dependencies:
   - bioconda::gtfparse>=1.0.7
   - python=3.6
   - cython
-  - scikit-learn=0.18.1
   - pandas=0.23.4
   - pip=20.3.3
   pip:
   - concise>=0.6.6
   - numpy>=1.13.3
+  - scikit-learn==0.19.0
 
 info:
   authors:


### PR DESCRIPTION
This should make the ci run faster - so frequent timeout resulting from circleci's allowed 1 hour/job  time should get better. 