### PR TITLE
Fixed ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,7 +258,6 @@ workflows:
                only:
                  - master
                  - test_all
-                 - fix-ci
        - sync_containers:
            context:
              - sync-kipoi-containers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,6 +258,7 @@ workflows:
                only:
                  - master
                  - test_all
+                 - fix-ci
        - sync_containers:
            context:
              - sync-kipoi-containers

--- a/shared/envs/kipoi-py3-keras1.2.yaml
+++ b/shared/envs/kipoi-py3-keras1.2.yaml
@@ -15,7 +15,7 @@ dependencies:
 - numpy
 - pandas
 - cython
-  - pip=21.3.1
+- pip=21.3.1
 - pip:
   - kipoi_veff
   - kipoi_interpret

--- a/shared/envs/kipoi-py3-keras1.2.yaml
+++ b/shared/envs/kipoi-py3-keras1.2.yaml
@@ -11,11 +11,11 @@ dependencies:
 - pysam
 - python=3.6
 - h5py
-- genomelake==0.1.4
+- genomelake=0.1.4
 - numpy
 - pandas
 - cython
-- pip=21.3.1
+  - pip=21.3.1
 - pip:
   - kipoi_veff
   - kipoi_interpret
@@ -26,3 +26,4 @@ dependencies:
   - deepcpg==1.0.4
   # other 
   - ipykernel
+  - typing-extensions==4.1.1

--- a/shared/envs/kipoi-py3-keras2.yaml
+++ b/shared/envs/kipoi-py3-keras2.yaml
@@ -12,7 +12,7 @@ dependencies:
 - bedtools
 - pybedtools
 - pysam
-- genomelake==0.1.4
+- genomelake=0.1.4
 - cython
 - h5py
 - pytorch-cpu>=0.2.0
@@ -23,7 +23,7 @@ dependencies:
 - ls-gkm=0.0.1
 - pybigwig
 - gtfparse>=1.0.7
-- scikit-learn==0.18.1
+- scikit-learn=0.18.1
 - pip:
   - kipoi_veff
   - kipoi_interpret
@@ -44,3 +44,4 @@ dependencies:
   - concise>=0.6.6
   # other 
   - ipykernel
+  - typing-extensions==4.1.1


### PR DESCRIPTION
Pinned typing-extensions to 4.1.1 since from the current version, they have dropped support for python 3.6