### PR TITLE
Upgrade python version from 3.6 to 3.7 in model dependencies 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,8 +230,8 @@ workflows:
        - test_new_models:
            matrix:
             parameters:
-              num_of_shards: [5]
-              shard_id: [0, 1, 2, 3, 4]
+              num_of_shards: [8]
+              shard_id: [0, 1, 2, 3, 4, 5, 6, 7]
            filters:
              branches:
                ignore:
@@ -247,6 +247,7 @@ workflows:
                ignore:
                  - master
                  - test_all
+                 - drop3.6
                       
   test-all-branch:
      jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,6 +189,11 @@ jobs:
 
 
   test_all_models_common_env:
+    parameters:
+      num_of_shards: 
+        type: integer
+      shard_id:
+        type: integer 
     <<: *defaults
     steps:
       - checkout
@@ -203,7 +208,7 @@ jobs:
       - run:
           name: run tests in common environments
           no_output_timeout: 60m
-          command: kipoi test-source kipoi --all --common_env
+          command: kipoi test-source kipoi --all --common_env --num_of_shards << parameters.num_of_shards >> --shard_id << parameters.shard_id >> --singularity
       - *store_artifacts
 
   date_release:
@@ -236,15 +241,18 @@ workflows:
        - test_new_models_singularity:
            matrix:
             parameters:
-              num_of_shards: [5]
-              shard_id: [0, 1, 2, 3, 4]
+              num_of_shards: [12]
+              shard_id: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
            filters:
              branches:
                ignore:
                  - master
                  - test_all
-                 - drop3.6
-       - test_all_models_common_env
+       - test_all_models_common_env: #TODO: write test_new_models_common_env
+           matrix:
+            parameters:
+              num_of_shards: [3]
+              shard_id: [0, 1, 2]
 
                       
   test-all-branch:
@@ -270,6 +278,10 @@ workflows:
                  - master
                  - test_all
        - test_all_models_common_env:
+           matrix:
+             parameters:
+               num_of_shards: [3]
+               shard_id: [0, 1, 2]
            filters:
              branches:
                only:
@@ -309,7 +321,11 @@ workflows:
             parameters:
               num_of_shards: [11]
               shard_id: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-       - test_all_models_common_env
+       - test_all_models_common_env:
+          matrix:
+            parameters:
+              num_of_shards: [3]
+              shard_id: [0, 1, 2]
 
 
   weekly-tag:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ jobs:
       - run:
           name: run tests in common environments
           no_output_timeout: 60m
-          command: kipoi test-source kipoi --all --common_env --num_of_shards << parameters.num_of_shards >> --shard_id << parameters.shard_id >> --singularity
+          command: kipoi test-source kipoi --all --common_env --num_of_shards << parameters.num_of_shards >> --shard_id << parameters.shard_id >>
       - *store_artifacts
 
   date_release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,11 @@ jobs:
 
   # test only the newly added model
   test_new_models:
+    parameters:
+      num_of_shards: 
+        type: integer
+      shard_id:
+        type: integer 
     <<: *defaults
     steps:
       - checkout
@@ -87,12 +92,17 @@ jobs:
           no_output_timeout: 60m
       - run:
           name: run tests in common environmnets
-          command: kipoi test-source kipoi --git-range master HEAD --common_env --num_of_shards << parameters.num_of_shards >> --shard_id << parameters.shard_id >>
+          command: kipoi test-source kipoi --git-range master HEAD --common_env
           no_output_timeout: 60m
       - *store_artifacts
     
   # test only the newly added model with singularity
   test_new_models_singularity:
+    parameters:
+      num_of_shards: 
+        type: integer
+      shard_id:
+        type: integer 
     <<: *defaults
     steps:
       - checkout
@@ -105,7 +115,7 @@ jobs:
       - *setup
       - run:
           name: run tests
-          command: kipoi test-source kipoi --git-range master HEAD --verbose --singularity
+          command: kipoi test-source kipoi --git-range master HEAD --verbose --singularity --num_of_shards << parameters.num_of_shards >> --shard_id << parameters.shard_id >>
           no_output_timeout: 60m
       - *store_artifacts
   
@@ -191,12 +201,20 @@ workflows:
   test-models:
      jobs:
        - test_new_models:
+           matrix:
+            parameters:
+              num_of_shards: [5]
+              shard_id: [0, 1, 2, 3, 4]
            filters:
              branches:
                ignore:
                  - master
                  - test_all
        - test_new_models_singularity:
+           matrix:
+            parameters:
+              num_of_shards: [5]
+              shard_id: [0, 1, 2, 3, 4]
            filters:
              branches:
                ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,7 +244,7 @@ workflows:
                  - master
                  - test_all
                  - drop3.6
-        - test_all_models_common_env
+       - test_all_models_common_env
 
                       
   test-all-branch:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,8 +230,8 @@ workflows:
        - test_new_models:
            matrix:
             parameters:
-              num_of_shards: [8]
-              shard_id: [0, 1, 2, 3, 4, 5, 6, 7]
+              num_of_shards: [12]
+              shard_id: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
            filters:
              branches:
                ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,11 +83,11 @@ jobs:
       - *setup
       - run:
           name: run tests
-          command: kipoi test-source kipoi --git-range master HEAD --verbose
+          command: kipoi test-source kipoi --git-range master HEAD --verbose --num_of_shards << parameters.num_of_shards >> --shard_id << parameters.shard_id >>
           no_output_timeout: 60m
       - run:
           name: run tests in common environmnets
-          command: kipoi test-source kipoi --git-range master HEAD --common_env
+          command: kipoi test-source kipoi --git-range master HEAD --common_env --num_of_shards << parameters.num_of_shards >> --shard_id << parameters.shard_id >>
           no_output_timeout: 60m
       - *store_artifacts
     

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,10 +109,6 @@ jobs:
           name: run tests
           command: kipoi test-source kipoi --git-range master HEAD --verbose --num_of_shards << parameters.num_of_shards >> --shard_id << parameters.shard_id >>
           no_output_timeout: 60m
-      - run:
-          name: run tests in common environmnets
-          command: kipoi test-source kipoi --git-range master HEAD --common_env
-          no_output_timeout: 60m
       - *store_artifacts
     
   # test only the newly added model with singularity
@@ -248,6 +244,8 @@ workflows:
                  - master
                  - test_all
                  - drop3.6
+        - test_all_models_common_env
+
                       
   test-all-branch:
      jobs:

--- a/AttentiveChrome/dataloader.yaml
+++ b/AttentiveChrome/dataloader.yaml
@@ -10,7 +10,7 @@ args:
     optional: true
 dependencies:
     conda: # install via conda
-      - python==3.6.3
+      - python==3.8
       - pytorch::pytorch-cpu
       - numpy     
 info: # General information about the dataloader

--- a/AttentiveChrome/dataloader.yaml
+++ b/AttentiveChrome/dataloader.yaml
@@ -10,7 +10,7 @@ args:
     optional: true
 dependencies:
     conda: # install via conda
-      - python==3.8
+      - python==3.7
       - pytorch::pytorch-cpu
       - numpy     
 info: # General information about the dataloader

--- a/AttentiveChrome/model-template.yaml
+++ b/AttentiveChrome/model-template.yaml
@@ -31,7 +31,7 @@ info: # General information about the model
         - RNA expression
 dependencies:
     conda: # install via conda
-      - python=3.6.3
+      - python=3.7
       - numpy=1.19.2
       - pytorch::pytorch-cpu=1.3.1
       - pytorch::torchvision-cpu=0.3.0

--- a/AttentiveChrome/model-template.yaml
+++ b/AttentiveChrome/model-template.yaml
@@ -43,3 +43,12 @@ schema:  # Model schema
     targets:
         shape: (1, )
         doc: "Binary Classification"
+
+
+{% if model == 'E003' %}
+test:
+  expect:
+    url: https://zenodo.org/record/6492433/files/AttentiveChrome__E003.predictions.h5?download=1
+    md5: b23ee2431c25691ed3391ceceb1dc4dd
+{% endif %}
+        

--- a/AttentiveChrome/model-template.yaml
+++ b/AttentiveChrome/model-template.yaml
@@ -34,7 +34,6 @@ dependencies:
       - python=3.7
       - numpy=1.19.2
       - pytorch::pytorch-cpu=1.3.1
-      - pytorch::torchvision-cpu=0.3.0
       - pip=21.0.1  
 schema:  # Model schema
     inputs:

--- a/BPNet-OSKN/model.yaml
+++ b/BPNet-OSKN/model.yaml
@@ -27,7 +27,7 @@ dependencies:
       - conda-forge
       - defaults
     conda:
-      - python=3.6
+      - python=3.7
       - bioconda::pybedtools>=0.7.10
       - bioconda::bedtools>=2.27.1
       - bioconda::pybigwig>=0.3.10

--- a/BPNet-OSKN/model.yaml
+++ b/BPNet-OSKN/model.yaml
@@ -66,3 +66,8 @@ schema:
       Klf4:
         shape: (1000,2)
         doc: "Strand-specific ChIP-nexus data for Klf4."        
+
+test:
+  expect:
+    url: https://zenodo.org/record/6492419/files/BPNet-OSKN.predictions.h5?download=1
+    md5: b2372e90e6611ff1def4e216c1e26320

--- a/BPNet-OSKN/model.yaml
+++ b/BPNet-OSKN/model.yaml
@@ -71,3 +71,4 @@ test:
   expect:
     url: https://zenodo.org/record/6492419/files/BPNet-OSKN.predictions.h5?download=1
     md5: b2372e90e6611ff1def4e216c1e26320
+  precision_decimal: 4

--- a/Basenji/model.yaml
+++ b/Basenji/model.yaml
@@ -56,7 +56,7 @@ dependencies:
     - pysam=0.16.0.1
     - cython=0.29.23
   pip:
-    - tensorflow==1.4.1
+    - tensorflow<2
     - kipoiseq
 schema:
   inputs:

--- a/Basenji/model.yaml
+++ b/Basenji/model.yaml
@@ -51,7 +51,7 @@ default_dataloader:
     ignore_targets: True  # don't return any output labels using the bed file
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
     - pip=20.2.4
     - pysam=0.16.0.1
     - cython=0.29.23

--- a/Basset/model.yaml
+++ b/Basset/model.yaml
@@ -15,13 +15,14 @@ default_dataloader:
 dependencies:
   conda:
   - python=3.7
-  - h5py=2.10.0
-  - _pytorch_select=0.2=gpu_0
-  - pytorch=1.3.1=cuda100py36h53c1284_0
+  - h5py=3.6.0
+  - _pytorch_select=0.1
+  - pytorch=1.8.1
   - pip=20.3.3
   - pysam=0.15.3
-  - cython=0.29.23
+  - cython=0.29.25
   pip:
+  - kipoi
   - kipoiseq
 info:
   authors:

--- a/Basset/model.yaml
+++ b/Basset/model.yaml
@@ -14,7 +14,7 @@ default_dataloader:
     dummy_axis: 2
 dependencies:
   conda:
-  - python=3.6
+  - python=3.7
   - h5py=2.10.0
   - _pytorch_select=0.2=gpu_0
   - pytorch=1.3.1=cuda100py36h53c1284_0

--- a/CleTimer/customBP/dataloader.yaml
+++ b/CleTimer/customBP/dataloader.yaml
@@ -38,7 +38,7 @@ info:
 
 dependencies:
     conda:
-        - python=3.6
+        - python=3.7
         - bioconda::gffutils
         - scipy
 output_schema:

--- a/CleTimer/default/dataloader.yaml
+++ b/CleTimer/default/dataloader.yaml
@@ -32,7 +32,7 @@ info:
 
 dependencies:
     conda:
-        - python=3.6
+        - python=3.7
         - bioconda::gffutils
         - scipy
     pip:

--- a/CpGenie/merged/model.yaml
+++ b/CpGenie/merged/model.yaml
@@ -36,12 +36,13 @@ default_dataloader:
     dummy_axis: 1
 dependencies:
   conda:
-    - python=3.6.12
-    - h5py=2.10.0
-    - tensorflow=1.10.0
-    - keras=1.2.2
+    - python=3.7
     - pysam=0.15.3
     - pip=20.2.4
+  pip:
+    - h5py==2.10.0
+    - tensorflow==1.15
+    - keras==1.2.2
 schema:
   inputs:
     name: seq

--- a/CpGenie/merged/model.yaml
+++ b/CpGenie/merged/model.yaml
@@ -36,7 +36,7 @@ default_dataloader:
     dummy_axis: 1
 dependencies:
   conda:
-    - python=3.6.12
+    - python=3.7
     - h5py=2.10.0
     - tensorflow=1.10.0
     - keras=1.2.2

--- a/CpGenie/merged/model.yaml
+++ b/CpGenie/merged/model.yaml
@@ -36,7 +36,7 @@ default_dataloader:
     dummy_axis: 1
 dependencies:
   conda:
-    - python=3.7
+    - python=3.6.12
     - h5py=2.10.0
     - tensorflow=1.10.0
     - keras=1.2.2

--- a/CpGenie/model-template.yaml
+++ b/CpGenie/model-template.yaml
@@ -48,7 +48,7 @@ default_dataloader:
     dummy_axis: 1
 dependencies:
   conda:
-    - python=3.6.12
+    - python=3.7
     - h5py=2.10.0
     - tensorflow=1.10.0
     - keras=1.2.2

--- a/CpGenie/model-template.yaml
+++ b/CpGenie/model-template.yaml
@@ -48,7 +48,7 @@ default_dataloader:
     dummy_axis: 1
 dependencies:
   conda:
-    - python=3.7
+    - python=3.6.12
     - h5py=2.10.0
     - tensorflow=1.10.0
     - keras=1.2.2

--- a/CpGenie/model-template.yaml
+++ b/CpGenie/model-template.yaml
@@ -48,12 +48,13 @@ default_dataloader:
     dummy_axis: 1
 dependencies:
   conda:
-    - python=3.6.12
-    - h5py=2.10.0
-    - tensorflow=1.10.0
-    - keras=1.2.2
+    - python=3.7
     - pysam=0.15.3
     - pip=20.2.4
+  pip:
+    - h5py==2.10.0
+    - tensorflow==1.15
+    - keras==1.2.2
 schema:
   inputs:
     name: seq

--- a/DeepBind/model-template.yaml
+++ b/DeepBind/model-template.yaml
@@ -38,10 +38,10 @@ default_dataloader:
 dependencies:
   conda:
     - h5py=2.10.0
-    - tensorflow=1.4.1
-    - keras=2.1.6
+    - tensorflow=2.7.0
+    - keras=2.7.0
     - python=3.7
-    - pysam=0.15.3
+    - pysam=0.18.0
     - pip=20.2.4
 schema:
   inputs:

--- a/DeepBind/model-template.yaml
+++ b/DeepBind/model-template.yaml
@@ -37,11 +37,10 @@ default_dataloader:
 
 dependencies:
   conda:
-    - python=3.6.12
     - h5py=2.10.0
     - tensorflow=1.4.1
     - keras=2.1.6
-    - python=3.6
+    - python=3.7
     - pysam=0.15.3
     - pip=20.2.4
 schema:

--- a/DeepCpG_DNA/Hou2016_HCC_dna/dataloader.yaml
+++ b/DeepCpG_DNA/Hou2016_HCC_dna/dataloader.yaml
@@ -14,7 +14,7 @@ dependencies:
   conda:
   - bioconda::genomelake=0.1.4
   - bioconda::pybedtools=0.8.1
-  - python=3.6
+  - python=3.7
   - numpy=1.19.2
   - pandas=1.1.3
 info:

--- a/DeepCpG_DNA/Hou2016_HCC_dna/model.yaml
+++ b/DeepCpG_DNA/Hou2016_HCC_dna/model.yaml
@@ -15,7 +15,7 @@ dependencies:
     - h5py=2.10.0
     - pip=20.2.4
   pip:
-    - tensorflow==1.10.0
+    - tensorflow==1.13.1
     - keras==1.2.2
 info:
   authors:

--- a/DeepCpG_DNA/Hou2016_HCC_dna/model.yaml
+++ b/DeepCpG_DNA/Hou2016_HCC_dna/model.yaml
@@ -11,7 +11,7 @@ args:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:

--- a/DeepCpG_DNA/Hou2016_HepG2_dna/dataloader.yaml
+++ b/DeepCpG_DNA/Hou2016_HepG2_dna/dataloader.yaml
@@ -14,7 +14,7 @@ dependencies:
   conda:
     - bioconda::genomelake=0.1.4
     - bioconda::pybedtools=0.8.1
-    - python=3.6
+    - python=3.7
     - numpy=1.19.2
     - pandas=1.1.3
 info:

--- a/DeepCpG_DNA/Hou2016_HepG2_dna/model.yaml
+++ b/DeepCpG_DNA/Hou2016_HepG2_dna/model.yaml
@@ -10,7 +10,7 @@ args:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:

--- a/DeepCpG_DNA/Hou2016_HepG2_dna/model.yaml
+++ b/DeepCpG_DNA/Hou2016_HepG2_dna/model.yaml
@@ -14,7 +14,7 @@ dependencies:
     - h5py=2.10.0
     - pip=20.2.4
   pip:
-    - tensorflow==1.10.0
+    - tensorflow==1.13.1
     - keras==1.2.2
 info:
   authors:

--- a/DeepCpG_DNA/Hou2016_mESC_dna/dataloader.yaml
+++ b/DeepCpG_DNA/Hou2016_mESC_dna/dataloader.yaml
@@ -14,7 +14,7 @@ dependencies:
   conda:
     - bioconda::genomelake=0.1.4
     - bioconda::pybedtools=0.8.1
-    - python=3.6
+    - python=3.7
     - numpy=1.19.2
     - pandas=1.1.3
 info:

--- a/DeepCpG_DNA/Hou2016_mESC_dna/model.yaml
+++ b/DeepCpG_DNA/Hou2016_mESC_dna/model.yaml
@@ -10,7 +10,7 @@ args:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:

--- a/DeepCpG_DNA/Hou2016_mESC_dna/model.yaml
+++ b/DeepCpG_DNA/Hou2016_mESC_dna/model.yaml
@@ -14,7 +14,7 @@ dependencies:
     - h5py=2.10.0
     - pip=20.2.4
   pip:
-    - tensorflow==1.10.0
+    - tensorflow==1.13.1
     - keras==1.2.2
 info:
   authors:

--- a/DeepCpG_DNA/Smallwood2014_2i_dna/dataloader.yaml
+++ b/DeepCpG_DNA/Smallwood2014_2i_dna/dataloader.yaml
@@ -14,7 +14,7 @@ dependencies:
   conda:
     - bioconda::genomelake=0.1.4
     - bioconda::pybedtools=0.8.1
-    - python=3.6
+    - python=3.7
     - numpy=1.19.2
     - pandas=1.1.3
 info:

--- a/DeepCpG_DNA/Smallwood2014_2i_dna/model.yaml
+++ b/DeepCpG_DNA/Smallwood2014_2i_dna/model.yaml
@@ -10,7 +10,7 @@ args:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:

--- a/DeepCpG_DNA/Smallwood2014_2i_dna/model.yaml
+++ b/DeepCpG_DNA/Smallwood2014_2i_dna/model.yaml
@@ -14,7 +14,7 @@ dependencies:
     - h5py=2.10.0
     - pip=20.2.4
   pip:
-    - tensorflow==1.10.0
+    - tensorflow==1.13.1
     - keras==1.2.2
 info:
   authors:

--- a/DeepCpG_DNA/Smallwood2014_serum_dna/dataloader.yaml
+++ b/DeepCpG_DNA/Smallwood2014_serum_dna/dataloader.yaml
@@ -14,7 +14,7 @@ dependencies:
   conda:
     - bioconda::genomelake=0.1.4
     - bioconda::pybedtools=0.8.1
-    - python=3.6
+    - python=3.7
     - numpy=1.19.2
     - pandas=1.1.3
 info:

--- a/DeepCpG_DNA/Smallwood2014_serum_dna/model.yaml
+++ b/DeepCpG_DNA/Smallwood2014_serum_dna/model.yaml
@@ -10,7 +10,7 @@ args:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:

--- a/DeepCpG_DNA/Smallwood2014_serum_dna/model.yaml
+++ b/DeepCpG_DNA/Smallwood2014_serum_dna/model.yaml
@@ -14,7 +14,7 @@ dependencies:
     - h5py=2.10.0
     - pip=20.2.4
   pip:
-    - tensorflow==1.10.0
+    - tensorflow==1.13.1
     - keras==1.2.2
 info:
   authors:

--- a/DeepCpG_DNA/template/dataloader.yaml
+++ b/DeepCpG_DNA/template/dataloader.yaml
@@ -18,7 +18,7 @@ dependencies:
   conda:
     - bioconda::genomelake=0.1.4
     - bioconda::pybedtools=0.8.1
-    - python=3.6
+    - python=3.7
     - numpy=1.19.2
     - pandas=1.1.3
 output_schema:

--- a/DeepCpG_DNA/template/dataloader_m_template.yaml
+++ b/DeepCpG_DNA/template/dataloader_m_template.yaml
@@ -23,7 +23,7 @@ dependencies:
   conda:
     - bioconda::genomelake=0.1.4
     - bioconda::pybedtools=0.8.1
-    - python=3.6
+    - python=3.7
     - numpy=1.19.2
     - pandas=1.1.3
 output_schema:

--- a/DeepCpG_DNA/template/model_template.yaml
+++ b/DeepCpG_DNA/template/model_template.yaml
@@ -23,7 +23,7 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:

--- a/DeepFlyBrain/dataloader.yaml
+++ b/DeepFlyBrain/dataloader.yaml
@@ -23,7 +23,7 @@ info:
 
 dependencies:
     conda:
-      - python=3.6
+      - python=3.7
       - cython=0.29.23
       - bioconda::pybedtools=0.8.2
       - bioconda::pysam=0.16.0.1

--- a/DeepFlyBrain/model.yaml
+++ b/DeepFlyBrain/model.yaml
@@ -24,7 +24,7 @@ info:
 
 dependencies:
     conda: # install via conda
-      - python=3.6
+      - python=3.7
       - h5py=2.10.0
       - keras=2.2.4
       - tensorflow=1.14.0

--- a/DeepMEL/DeepMEL/dataloader.yaml
+++ b/DeepMEL/DeepMEL/dataloader.yaml
@@ -24,12 +24,12 @@ info:
 dependencies:
     conda:
       - python=3.7
-      - bioconda::pybedtools
-      - bioconda::pysam
-      - bioconda::pyfaidx
-      - numpy
-      - pandas
-      - cython=0.29.23
+      - bioconda::pybedtools=0.8.2
+      - bioconda::pysam=0.18.0
+      - bioconda::pyfaidx=0.6.4
+      - numpy=1.21.5
+      - pandas=1.1.5
+      - cython=0.29.28
     pip:
       - kipoiseq
 

--- a/DeepMEL/DeepMEL/dataloader.yaml
+++ b/DeepMEL/DeepMEL/dataloader.yaml
@@ -23,7 +23,7 @@ info:
 
 dependencies:
     conda:
-      - python=3.6
+      - python=3.7
       - bioconda::pybedtools
       - bioconda::pysam
       - bioconda::pyfaidx

--- a/DeepMEL/DeepMEL/model.yaml
+++ b/DeepMEL/DeepMEL/model.yaml
@@ -40,3 +40,8 @@ schema:
        name: topic
        shape: (24,)
        doc: Topic Prediction (4-MEL, 7-MES)
+
+test:
+  expect:
+    url: https://zenodo.org/record/6492407/files/DeepMEL__DeepMEL.predictions.h5?download=1
+    md5: a94aab8c23778d1de870eac76be7eff2

--- a/DeepMEL/DeepMEL/model.yaml
+++ b/DeepMEL/DeepMEL/model.yaml
@@ -24,11 +24,11 @@ info:
 dependencies:
     conda: # install via conda
       - python=3.7
-      - h5py=2.10.0
+      - h5py=3.6.0
       - pip=20.2.4
     pip:   # install via pip
-      - keras==2.4.3
-      - tensorflow==2.3.1
+      - keras==2.8.0
+      - tensorflow==2.8.0
 
 schema:  
      inputs: 

--- a/DeepMEL/DeepMEL/model.yaml
+++ b/DeepMEL/DeepMEL/model.yaml
@@ -23,7 +23,7 @@ info:
 
 dependencies:
     conda: # install via conda
-      - python=3.6
+      - python=3.7
       - h5py=2.10.0
       - pip=20.2.4
     pip:   # install via pip

--- a/DeepMEL/DeepMEL2/dataloader.yaml
+++ b/DeepMEL/DeepMEL2/dataloader.yaml
@@ -24,12 +24,12 @@ info:
 dependencies:
     conda:
       - python=3.7
-      - bioconda::pybedtools
-      - bioconda::pysam
-      - bioconda::pyfaidx
-      - numpy
-      - pandas
-      - cython=0.29.23
+      - bioconda::pybedtools=0.8.2
+      - bioconda::pysam=0.18.0
+      - bioconda::pyfaidx=0.6.4
+      - numpy=1.21.5
+      - pandas=1.1.5
+      - cython=0.29.28
     pip:
       - kipoiseq
 

--- a/DeepMEL/DeepMEL2/dataloader.yaml
+++ b/DeepMEL/DeepMEL2/dataloader.yaml
@@ -23,7 +23,7 @@ info:
 
 dependencies:
     conda:
-      - python=3.6
+      - python=3.7
       - bioconda::pybedtools
       - bioconda::pysam
       - bioconda::pyfaidx

--- a/DeepMEL/DeepMEL2/model.yaml
+++ b/DeepMEL/DeepMEL2/model.yaml
@@ -40,3 +40,7 @@ schema:
        name: topic
        shape: (47,)
        doc: Topic Prediction
+test:
+  expect:
+    url: https://zenodo.org/record/6492364/files/DeepMEL__DeepMEL2.predictions.h5?download=1
+    md5: a202fb891ba49f0e2e52be0681ce23ba

--- a/DeepMEL/DeepMEL2/model.yaml
+++ b/DeepMEL/DeepMEL2/model.yaml
@@ -23,7 +23,7 @@ info:
 
 dependencies:
     conda: # install via conda
-      - python=3.6
+      - python=3.7
       - h5py=2.10.0
       - pip=20.2.4
     pip:   # install via pip

--- a/DeepMEL/DeepMEL2/model.yaml
+++ b/DeepMEL/DeepMEL2/model.yaml
@@ -22,13 +22,13 @@ info:
     license: MIT
 
 dependencies:
-    conda: # install via conda
-      - python=3.7
-      - h5py=2.10.0
-      - pip=20.2.4
-    pip:   # install via pip
-      - keras==2.4.3
-      - tensorflow==2.3.1
+  conda: # install via conda
+    - python=3.7
+    - h5py=3.6.0
+    - pip=20.2.4
+  pip:   # install via pip
+    - keras==2.8.0
+    - tensorflow==2.8.0
       
 schema:  
      inputs: 

--- a/DeepMEL/DeepMEL2_GABPA/dataloader.yaml
+++ b/DeepMEL/DeepMEL2_GABPA/dataloader.yaml
@@ -24,12 +24,12 @@ info:
 dependencies:
     conda:
       - python=3.7
-      - cython=0.29.23
       - bioconda::pybedtools=0.8.2
-      - bioconda::pysam=0.16.0.1
-      - bioconda::pyfaidx=0.6.1
-      - numpy=1.19.5
+      - bioconda::pysam=0.18.0
+      - bioconda::pyfaidx=0.6.4
+      - numpy=1.21.5
       - pandas=1.1.5
+      - cython=0.29.28
     pip:
       - kipoiseq
 

--- a/DeepMEL/DeepMEL2_GABPA/dataloader.yaml
+++ b/DeepMEL/DeepMEL2_GABPA/dataloader.yaml
@@ -23,7 +23,7 @@ info:
 
 dependencies:
     conda:
-      - python=3.6
+      - python=3.7
       - cython=0.29.23
       - bioconda::pybedtools=0.8.2
       - bioconda::pysam=0.16.0.1

--- a/DeepMEL/DeepMEL2_GABPA/model.yaml
+++ b/DeepMEL/DeepMEL2_GABPA/model.yaml
@@ -40,3 +40,8 @@ schema:
        name: topic
        shape: (48,)
        doc: Topic Prediction
+
+test:
+  expect:
+    url: https://zenodo.org/record/6492385/files/DeepMEL__DeepMEL2_GABPA.predictions.h5?download=1
+    md5: 464527f641557d63bd1f3d4f78a587d3

--- a/DeepMEL/DeepMEL2_GABPA/model.yaml
+++ b/DeepMEL/DeepMEL2_GABPA/model.yaml
@@ -24,11 +24,11 @@ info:
 dependencies:
     conda: # install via conda
       - python=3.7
-      - h5py=2.10.0
+      - h5py=3.6.0
       - pip=20.2.4
     pip:   # install via pip
-      - keras==2.4.3
-      - tensorflow==2.3.1
+      - keras==2.8.0
+      - tensorflow==2.8.0
       
 schema:  
      inputs: 

--- a/DeepMEL/DeepMEL2_GABPA/model.yaml
+++ b/DeepMEL/DeepMEL2_GABPA/model.yaml
@@ -23,7 +23,7 @@ info:
 
 dependencies:
     conda: # install via conda
-      - python=3.6
+      - python=3.7
       - h5py=2.10.0
       - pip=20.2.4
     pip:   # install via pip

--- a/DeepSEA/beluga/model.yaml
+++ b/DeepSEA/beluga/model.yaml
@@ -39,7 +39,7 @@ dependencies:
     - pytorch::pytorch-cpu=1.3.1
     - cython=0.29.23
   pip:
-    - kipoi<=0.6.35
+    - kipoi
     - kipoiseq
 
 schema:

--- a/DeepSEA/beluga/model.yaml
+++ b/DeepSEA/beluga/model.yaml
@@ -33,7 +33,7 @@ default_dataloader:
 
 dependencies:
   conda:
-    - python=3.6.12
+    - python=3.7
     - pip=20.2.4
     - h5py=2.10.0
     - pytorch::pytorch-cpu=1.3.1

--- a/DeepSEA/predict/model.yaml
+++ b/DeepSEA/predict/model.yaml
@@ -45,7 +45,7 @@ default_dataloader:
     dtype: np.float32
 dependencies:
   conda:
-    - python=3.6.12
+    - python=3.7
     - h5py=2.10.0
     - pytorch::pytorch-cpu=1.3.1
     - pip=20.2.4

--- a/DeepSEA/variantEffects/model.yaml
+++ b/DeepSEA/variantEffects/model.yaml
@@ -50,7 +50,7 @@ dependencies:
     - pip=20.2.4
     - cython=0.29.23
   pip:
-    - kipoi<=0.6.35
+    - kipoi
     - kipoiseq
 schema:
   inputs:

--- a/DeepSEA/variantEffects/model.yaml
+++ b/DeepSEA/variantEffects/model.yaml
@@ -44,7 +44,7 @@ default_dataloader:
     dtype: np.float32
 dependencies:
   conda:
-    - python=3.6.12
+    - python=3.7
     - h5py=2.10.0
     - pytorch::pytorch-cpu=1.3.1
     - pip=20.2.4

--- a/FactorNet/CEBPB/meta_Unique35_DGF/model.yaml
+++ b/FactorNet/CEBPB/meta_Unique35_DGF/model.yaml
@@ -10,7 +10,7 @@ args:
 default_dataloader: .
 dependencies:
   conda:
-  - python=3.6
+  - python=3.7
   pip:
   - tensorflow>=1.4.1,<2.0.0,<=1.14.0
   - keras>=2.0.4,<2.2.0

--- a/FactorNet/CEBPB/onePeak_1_DGF/model.yaml
+++ b/FactorNet/CEBPB/onePeak_1_DGF/model.yaml
@@ -10,7 +10,7 @@ args:
 default_dataloader: .
 dependencies:
   conda:
-  - python=3.6
+  - python=3.7
   pip:
   - tensorflow>=1.4.1,<2.0.0
   - keras>=2.0.4,<2.2.0

--- a/FactorNet/CEBPB/onePeak_2_Unique35_DGF/model.yaml
+++ b/FactorNet/CEBPB/onePeak_2_Unique35_DGF/model.yaml
@@ -10,7 +10,7 @@ args:
 default_dataloader: .
 dependencies:
   conda:
-  - python=3.6
+  - python=3.7
   pip:
   - tensorflow>=1.4.1,<2.0.0
   - keras>=2.0.4,<2.2.0

--- a/FactorNet/CTCF/metaGENCODE_RNAseq_Unique35_DGF/model.yaml
+++ b/FactorNet/CTCF/metaGENCODE_RNAseq_Unique35_DGF/model.yaml
@@ -58,7 +58,7 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
     - pip=20.3.3
     - pysam=0.15.3
   pip:

--- a/FactorNet/CTCF/meta_RNAseq_Unique35_DGF/model.yaml
+++ b/FactorNet/CTCF/meta_RNAseq_Unique35_DGF/model.yaml
@@ -58,7 +58,7 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
     - pip=20.3.3
   pip:
     - tensorflow==1.4.1

--- a/FactorNet/E2F1/GENCODE_Unique35_DGF/model.yaml
+++ b/FactorNet/E2F1/GENCODE_Unique35_DGF/model.yaml
@@ -58,7 +58,7 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
   pip:
     - tensorflow>=1.4.1,<2.0.0
     - keras>=2.0.4,<2.2.0

--- a/FactorNet/E2F1/onePeak_Unique35_DGF/model.yaml
+++ b/FactorNet/E2F1/onePeak_Unique35_DGF/model.yaml
@@ -58,7 +58,7 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
   pip:
     - tensorflow>=1.4.1,<2.0.0
     - keras>=2.0.4,<2.2.0

--- a/FactorNet/EGR1/meta_RNAseq_Unique35_DGF/model.yaml
+++ b/FactorNet/EGR1/meta_RNAseq_Unique35_DGF/model.yaml
@@ -58,7 +58,7 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
   pip:
     - tensorflow>=1.4.1,<2.0.0
     - keras>=2.0.4,<2.2.0

--- a/FactorNet/EGR1/onePeak_DGF/model.yaml
+++ b/FactorNet/EGR1/onePeak_DGF/model.yaml
@@ -58,7 +58,7 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
   pip:
     - tensorflow>=1.4.1,<2.0.0
     - keras>=2.0.4,<2.2.0

--- a/FactorNet/FOXA1/multiTask_DGF/model.yaml
+++ b/FactorNet/FOXA1/multiTask_DGF/model.yaml
@@ -58,7 +58,7 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
   pip:
     - tensorflow>=1.4.1,<2.0.0
     - keras>=2.0.4,<2.2.0

--- a/FactorNet/FOXA1/onePeak_DGF/model.yaml
+++ b/FactorNet/FOXA1/onePeak_DGF/model.yaml
@@ -58,7 +58,7 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
   pip:
     - tensorflow>=1.4.1,<2.0.0
     - keras>=2.0.4,<2.2.0

--- a/FactorNet/FOXA2/multiTask_DGF/model.yaml
+++ b/FactorNet/FOXA2/multiTask_DGF/model.yaml
@@ -58,7 +58,7 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
   pip:
     - tensorflow>=1.4.1,<2.0.0
     - keras>=2.0.4,<2.2.0

--- a/FactorNet/FOXA2/onePeak_Unique35_DGF/model.yaml
+++ b/FactorNet/FOXA2/onePeak_Unique35_DGF/model.yaml
@@ -58,7 +58,7 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
   pip:
     - tensorflow>=1.4.1,<2.0.0
     - keras>=2.0.4,<2.2.0

--- a/FactorNet/GABPA/metaGENCODE_RNAseq_Unique35_DGF/model.yaml
+++ b/FactorNet/GABPA/metaGENCODE_RNAseq_Unique35_DGF/model.yaml
@@ -58,7 +58,7 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
   pip:
     - tensorflow>=1.4.1,<2.0.0
     - keras>=2.0.4,<2.2.0

--- a/FactorNet/GABPA/meta_RNAseq_Unique35_DGF/model.yaml
+++ b/FactorNet/GABPA/meta_RNAseq_Unique35_DGF/model.yaml
@@ -58,7 +58,7 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
   pip:
     - tensorflow>=1.4.1,<2.0.0
     - keras>=2.0.4,<2.2.0

--- a/FactorNet/HNF4A/multiTask_DGF/model.yaml
+++ b/FactorNet/HNF4A/multiTask_DGF/model.yaml
@@ -58,7 +58,7 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
   pip:
     - tensorflow>=1.4.1,<2.0.0
     - keras>=2.0.4,<2.2.0

--- a/FactorNet/HNF4A/onePeak_Unique35_DGF/model.yaml
+++ b/FactorNet/HNF4A/onePeak_Unique35_DGF/model.yaml
@@ -58,7 +58,7 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
   pip:
     - tensorflow>=1.4.1,<2.0.0
     - keras>=2.0.4,<2.2.0

--- a/FactorNet/JUND/meta_Unique35_DGF/model.yaml
+++ b/FactorNet/JUND/meta_Unique35_DGF/model.yaml
@@ -58,7 +58,7 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
   pip:
     - tensorflow>=1.4.1,<2.0.0
     - keras>=2.0.4,<2.2.0

--- a/FactorNet/JUND/meta_Unique35_DGF_2/model.yaml
+++ b/FactorNet/JUND/meta_Unique35_DGF_2/model.yaml
@@ -58,7 +58,7 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
   pip:
     - tensorflow>=1.4.1,<2.0.0
     - keras>=2.0.4,<2.2.0

--- a/FactorNet/MAFK/meta_1_Unique35_DGF/model.yaml
+++ b/FactorNet/MAFK/meta_1_Unique35_DGF/model.yaml
@@ -10,7 +10,7 @@ args:
 default_dataloader: .
 dependencies:
   conda:
-  - python=3.6
+  - python=3.7
   pip:
   - tensorflow>=1.4.1,<2.0.0
   - keras>=2.0.4,<2.2.0

--- a/FactorNet/MAFK/onePeak_1_DGF/model.yaml
+++ b/FactorNet/MAFK/onePeak_1_DGF/model.yaml
@@ -10,7 +10,7 @@ args:
 default_dataloader: .
 dependencies:
   conda:
-  - python=3.6
+  - python=3.7
   pip:
   - tensorflow>=1.4.1,<2.0.0
   - keras>=2.0.4,<2.2.0

--- a/FactorNet/MAFK/onePeak_2_Unique35_DGF/model.yaml
+++ b/FactorNet/MAFK/onePeak_2_Unique35_DGF/model.yaml
@@ -10,7 +10,7 @@ args:
 default_dataloader: .
 dependencies:
   conda:
-  - python=3.6
+  - python=3.7
   pip:
   - tensorflow>=1.4.1,<2.0.0
   - keras>=2.0.4,<2.2.0

--- a/FactorNet/MAX/onePeak_Unique35_DGF/model.yaml
+++ b/FactorNet/MAX/onePeak_Unique35_DGF/model.yaml
@@ -58,7 +58,7 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
   pip:
     - tensorflow>=1.4.1,<2.0.0
     - keras>=2.0.4,<2.2.0

--- a/FactorNet/MAX/onePeak_Unique35_DGF_2/model.yaml
+++ b/FactorNet/MAX/onePeak_Unique35_DGF_2/model.yaml
@@ -58,7 +58,7 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
   pip:
     - tensorflow>=1.4.1,<2.0.0
     - keras>=2.0.4,<2.2.0

--- a/FactorNet/NANOG/GENCODE_Unique35_DGF/model.yaml
+++ b/FactorNet/NANOG/GENCODE_Unique35_DGF/model.yaml
@@ -58,7 +58,7 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
   pip:
     - tensorflow>=1.4.1,<2.0.0
     - keras>=2.0.4,<2.2.0

--- a/FactorNet/NANOG/onePeak_Unique35_DGF/model.yaml
+++ b/FactorNet/NANOG/onePeak_Unique35_DGF/model.yaml
@@ -58,7 +58,7 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
   pip:
     - tensorflow>=1.4.1,<2.0.0
     - keras>=2.0.4,<2.2.0

--- a/FactorNet/REST/GENCODE_Unique35_DGF/model.yaml
+++ b/FactorNet/REST/GENCODE_Unique35_DGF/model.yaml
@@ -58,7 +58,7 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
   pip:
     - tensorflow>=1.4.1,<2.0.0
     - keras>=2.0.4,<2.2.0

--- a/FactorNet/REST/GENCODE_Unique35_DGF_2/model.yaml
+++ b/FactorNet/REST/GENCODE_Unique35_DGF_2/model.yaml
@@ -58,7 +58,7 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
   pip:
     - tensorflow>=1.4.1,<2.0.0
     - keras>=2.0.4,<2.2.0

--- a/FactorNet/TAF1/GENCODE_Unique35_DGF/model.yaml
+++ b/FactorNet/TAF1/GENCODE_Unique35_DGF/model.yaml
@@ -58,7 +58,7 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
   pip:
     - tensorflow>=1.4.1,<2.0.0
     - keras>=2.0.4,<2.2.0

--- a/FactorNet/TAF1/onePeak_Unique35_DGF/model.yaml
+++ b/FactorNet/TAF1/onePeak_Unique35_DGF/model.yaml
@@ -58,7 +58,7 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
   pip:
     - tensorflow>=1.4.1,<2.0.0
     - keras>=2.0.4,<2.2.0

--- a/FactorNet/template/template_model.yaml
+++ b/FactorNet/template/template_model.yaml
@@ -58,7 +58,7 @@ info:
 default_dataloader: .
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
     - pip=20.3.3
     - pysam=0.15.2
   pip:

--- a/Framepool/dataloader.yaml
+++ b/Framepool/dataloader.yaml
@@ -52,7 +52,7 @@ dependencies:
     - conda-forge
     - defaults
   conda:
-    - python=3.6.7
+    - python=3.7
     - bioconda::pybedtools>=0.8.0
     - bioconda::biopython
     - bioconda::bedtools>=2.28.0

--- a/Framepool/model.yaml
+++ b/Framepool/model.yaml
@@ -8,7 +8,7 @@ default_dataloader: .
 
 dependencies:
   conda:
-    - python=3.6.7
+    - python=3.7
     - numpy>=1.16.2
     - tensorflow=1.13.1
     - keras=2.2.4

--- a/Framepool/model.yaml
+++ b/Framepool/model.yaml
@@ -69,4 +69,5 @@ test:
   expect:
     url: https://zenodo.org/record/6492255/files/Framepool.predictions.h5?download=1
     md5: 3d836e1150a7f2b9156fa43f2fbf22c5
-      
+  precision_decimal: 5
+   

--- a/Framepool/model.yaml
+++ b/Framepool/model.yaml
@@ -64,3 +64,9 @@ schema:
     shift_2:
       shape: (1,)
       doc: Log2 Fold Change in mrl if frame is shifted by 2
+
+test:
+  expect:
+    url: https://zenodo.org/record/6492255/files/Framepool.predictions.h5?download=1
+    md5: 3d836e1150a7f2b9156fa43f2fbf22c5
+      

--- a/HAL/dataloader.yaml
+++ b/HAL/dataloader.yaml
@@ -20,7 +20,7 @@ defined_as: dataloader.py::SplicingKmerDataset
 dependencies:
   conda:
   - bioconda::pysam
-  - python=3.6
+  - python=3.7
 info:
   authors:
   - github: s6juncheng

--- a/HAL/model.yaml
+++ b/HAL/model.yaml
@@ -40,7 +40,7 @@ dependencies:
     - tinydb==4.2.0
     - tqdm==4.51.0
     - urllib3==1.25.11
-    - kipoi==0.6.35
+    - kipoi
     - kipoi-conda
     - kipoi-utils
 info:

--- a/HAL/model.yaml
+++ b/HAL/model.yaml
@@ -7,7 +7,7 @@ defined_as: model.HALModel
 dependencies:
   conda:
     - numpy=1.19.2
-    - python=3.6
+    - python=3.7
     - pip=20.2.4
     - cython=0.29.23
   pip:

--- a/KipoiSplice/4/dataloader.yaml
+++ b/KipoiSplice/4/dataloader.yaml
@@ -41,7 +41,7 @@ dependencies:
   - joblib
   - scikit-learn
   - sklearn-pandas
-  - kipoi==0.6.30
+  - kipoi
   - kipoi_utils==0.7.2
   - kipoi_veff
   - tqdm

--- a/KipoiSplice/4/dataloader.yaml
+++ b/KipoiSplice/4/dataloader.yaml
@@ -41,7 +41,7 @@ dependencies:
   - joblib
   - scikit-learn
   - sklearn-pandas
-  - kipoi
+  - kipoi==0.6.30
   - kipoi_utils==0.7.2
   - kipoi_veff
   - tqdm

--- a/KipoiSplice/4cons/dataloader.yaml
+++ b/KipoiSplice/4cons/dataloader.yaml
@@ -45,7 +45,7 @@ dependencies:
   - joblib
   - scikit-learn
   - sklearn-pandas
-  - kipoi
+  - kipoi==0.6.30 
   - kipoi_utils==0.7.2
   - kipoi_veff
   - tqdm

--- a/KipoiSplice/4cons/dataloader.yaml
+++ b/KipoiSplice/4cons/dataloader.yaml
@@ -45,7 +45,7 @@ dependencies:
   - joblib
   - scikit-learn
   - sklearn-pandas
-  - kipoi==0.6.30 
+  - kipoi
   - kipoi_utils==0.7.2
   - kipoi_veff
   - tqdm

--- a/MMSplice/dataloader.yaml
+++ b/MMSplice/dataloader.yaml
@@ -67,7 +67,7 @@ dependencies:
     - bioconda::cyvcf2=0.11.5
     - bioconda::pyranges=0.0.66
     - bioconda::pysam=0.15.3
-    - python=3.6
+    - python=3.7
   pip:
     - mmsplice==1.0.3
 output_schema:

--- a/MMSplice/deltaLogitPSI/model.yaml
+++ b/MMSplice/deltaLogitPSI/model.yaml
@@ -15,7 +15,7 @@ info:
         - RNA splicing
 dependencies:
     conda:
-      - python=3.6.13
+      - python=3.7
       - pip=21.0.1
     pip:
       - h5py==2.10.0

--- a/MMSplice/modularPredictions/model.yaml
+++ b/MMSplice/modularPredictions/model.yaml
@@ -15,7 +15,7 @@ info:
         - RNA splicing
 dependencies:
   conda:
-    - python=3.6.13
+    - python=3.7
     - pip=21.0.1
   pip:
     - h5py==2.10.0

--- a/MMSplice/mtsplice/dataloader.yaml
+++ b/MMSplice/mtsplice/dataloader.yaml
@@ -67,7 +67,7 @@ dependencies:
     - bioconda::cyvcf2=0.11.5
     - bioconda::pyranges=0.0.71
     - bioconda::pysam=0.15.3
-    - python=3.6
+    - python=3.7
   pip:
     - mmsplice==2.0.0
 output_schema:

--- a/MMSplice/mtsplice/model.yaml
+++ b/MMSplice/mtsplice/model.yaml
@@ -15,7 +15,7 @@ info:
         - RNA splicing
 dependencies:
     conda:
-    - python=3.6.13
+    - python=3.7
     - pip=21.0.1
     pip:
       - h5py==2.10.0

--- a/MMSplice/pathogenicity/model.yaml
+++ b/MMSplice/pathogenicity/model.yaml
@@ -16,7 +16,7 @@ info:
         - RNA splicing
 dependencies:
   conda:
-    - python=3.6.13
+    - python=3.7
     - pip=21.0.1
   pip:
     - h5py==2.10.0

--- a/MMSplice/splicingEfficiency/model.yaml
+++ b/MMSplice/splicingEfficiency/model.yaml
@@ -15,7 +15,7 @@ info:
         - RNA splicing
 dependencies:
   conda:
-    - python=3.6.13
+    - python=3.7
     - pip=21.0.1
   pip:
     - h5py==2.10.0

--- a/MPRA-DragoNN/ConvModel/model.yaml
+++ b/MPRA-DragoNN/ConvModel/model.yaml
@@ -54,4 +54,5 @@ test:
   expect:
     url: https://zenodo.org/record/6492201/files/MPRA-DragoNN__ConvModel.predictions.h5?download=1
     md5: 34242ec19bd5e41bb5c6f5f06c2e6c41
-                                    
+  precision_decimal: 4
+                                

--- a/MPRA-DragoNN/ConvModel/model.yaml
+++ b/MPRA-DragoNN/ConvModel/model.yaml
@@ -49,3 +49,9 @@ schema:  # Model schema. The schema defintion is essential for kipoi plug-ins to
                                 k562 sv40p replicate 1, k562 sv40p replicate 2, k562 sv40p pooled,
                                 hepg2 minP replicate 1, hepg2 minP replicate 2, hepg2 minP pooled,
                                 hepg2 sv40p replicate 1, hepg2 sv40p replicate 2, hepg2 sv40p pooled."
+
+test:
+  expect:
+    url: https://zenodo.org/record/6492201/files/MPRA-DragoNN__ConvModel.predictions.h5?download=1
+    md5: 34242ec19bd5e41bb5c6f5f06c2e6c41
+                                    

--- a/MPRA-DragoNN/ConvModel/model.yaml
+++ b/MPRA-DragoNN/ConvModel/model.yaml
@@ -33,7 +33,7 @@ dependencies:
     conda: # install via conda
       - cython=0.28.5
       - h5py=2.8.0
-      - python=3.6
+      - python=3.7
       - pip=20.3.3
       # - soumith::pytorch  # <channel>::<package> syntax
     pip:   # install via pip

--- a/MPRA-DragoNN/DeepFactorizedModel/model.yaml
+++ b/MPRA-DragoNN/DeepFactorizedModel/model.yaml
@@ -32,7 +32,7 @@ info: # General information about the model
 dependencies:
     conda: # install via conda
       - cython=0.28.5
-      - python=3.6
+      - python=3.7
       - h5py=2.8.0
       - pip=20.3.3
       # - soumith::pytorch  # <channel>::<package> syntax

--- a/MPRA-DragoNN/DeepFactorizedModel/model.yaml
+++ b/MPRA-DragoNN/DeepFactorizedModel/model.yaml
@@ -54,4 +54,5 @@ test:
   expect:
     url: https://zenodo.org/record/6492191/files/MPRA-DragoNN__DeepFactorizedModel.predictions.h5?download=1
     md5: 8c7f7ebdea5208675c2ba75fea039038
-                                  
+  precision_decimal: 4
+                                

--- a/MPRA-DragoNN/DeepFactorizedModel/model.yaml
+++ b/MPRA-DragoNN/DeepFactorizedModel/model.yaml
@@ -50,3 +50,8 @@ schema:  # Model schema. The schema defintion is essential for kipoi plug-ins to
                                 k562 sv40p replicate 1, k562 sv40p replicate 2, k562 sv40p pooled,
                                 hepg2 minP replicate 1, hepg2 minP replicate 2, hepg2 minP pooled,
                                 hepg2 sv40p replicate 1, hepg2 sv40p replicate 2, hepg2 sv40p pooled."
+test:
+  expect:
+    url: https://zenodo.org/record/6492191/files/MPRA-DragoNN__DeepFactorizedModel.predictions.h5?download=1
+    md5: 8c7f7ebdea5208675c2ba75fea039038
+                                  

--- a/MaxEntScan/dataloader.py
+++ b/MaxEntScan/dataloader.py
@@ -81,7 +81,7 @@ class SplicingMaxEntDataset(Dataset):
     dependencies:
       conda:
         - pysam=0.15.2
-        - python=3.6.6
+        - python=3.7
     info:
       authors:
         - github: s6juncheng

--- a/MaxEntScan/dataloader.yaml
+++ b/MaxEntScan/dataloader.yaml
@@ -23,7 +23,7 @@ dependencies:
   conda:
   - pip=20.2.4
   - pysam=0.15.2
-  - python=3.6.6
+  - python=3.7
 info:
   authors:
   - github: s6juncheng

--- a/MaxEntScan/model-template.yaml
+++ b/MaxEntScan/model-template.yaml
@@ -30,7 +30,7 @@ dependencies:
       - pip=20.2.4
       - bioconda::maxentpy=0.0.1
     pip:
-      - kipoi==0.6.35
+      - kipoi
 schema:
     inputs:
         name: seq

--- a/Optimus_5Prime/dataloader.yaml
+++ b/Optimus_5Prime/dataloader.yaml
@@ -19,7 +19,7 @@ defined_as: dataloader.py::FixedSeq5UtrDl
 
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
     - pip=20.2.4
     - bioconda::pybedtools=0.8.1
   pip:

--- a/Optimus_5Prime/dataloader.yaml
+++ b/Optimus_5Prime/dataloader.yaml
@@ -21,7 +21,7 @@ dependencies:
   conda:
     - python=3.7
     - pip=20.2.4
-    - bioconda::pybedtools=0.8.1
+    - bioconda::pybedtools=0.8.2
   pip:
     - kipoi
     - kipoiseq

--- a/Optimus_5Prime/model.yaml
+++ b/Optimus_5Prime/model.yaml
@@ -13,7 +13,7 @@ dependencies:
   conda:
   - tensorflow=1.4.1
   - keras=2.1.6
-  - python=3.6
+  - python=3.7
   - pip=20.2.4
 
 info:

--- a/Optimus_5Prime/model.yaml
+++ b/Optimus_5Prime/model.yaml
@@ -11,8 +11,8 @@ default_dataloader: .
 
 dependencies:
   conda:
-  - tensorflow=1.4.1
-  - keras=2.1.6
+  - tensorflow=2.6.0
+  - keras=2.6.0
   - python=3.7
   - pip=20.2.4
 

--- a/SeqVec/embedding/dataloader.yaml
+++ b/SeqVec/embedding/dataloader.yaml
@@ -23,7 +23,7 @@ info:
 
 dependencies:
     conda:
-      - python=3.7
+      - python=3.6
       - conda-forge::allennlp=0.7.2
     # pip:
     #   - allennlp

--- a/SeqVec/embedding/dataloader.yaml
+++ b/SeqVec/embedding/dataloader.yaml
@@ -23,7 +23,7 @@ info:
 
 dependencies:
     conda:
-      - python=3.6
+      - python=3.7
       - conda-forge::allennlp=0.7.2
     # pip:
     #   - allennlp

--- a/SeqVec/embedding/model.yaml
+++ b/SeqVec/embedding/model.yaml
@@ -23,7 +23,7 @@ info: # General information about the model
 
 dependencies:
     conda: # install via conda
-      - python=3.7
+      - python=3.6
       - conda-forge::allennlp=0.7.2
       - pip=9.0.3
       - scikit-learn==0.22.2.post1

--- a/SeqVec/embedding/model.yaml
+++ b/SeqVec/embedding/model.yaml
@@ -23,7 +23,7 @@ info: # General information about the model
 
 dependencies:
     conda: # install via conda
-      - python=3.6
+      - python=3.7
       - conda-forge::allennlp=0.7.2
       - pip=9.0.3
       - scikit-learn==0.22.2.post1

--- a/SeqVec/embedding2structure/model.yaml
+++ b/SeqVec/embedding2structure/model.yaml
@@ -21,7 +21,7 @@ info: # General information about the model
         
 dependencies:
     conda: # install via conda
-      - python=3.6
+      - python=3.7
       - conda-forge::allennlp=0.7.2
       - pip=9.0.3
     pip:

--- a/SeqVec/embedding2structure/model.yaml
+++ b/SeqVec/embedding2structure/model.yaml
@@ -21,7 +21,7 @@ info: # General information about the model
         
 dependencies:
     conda: # install via conda
-      - python=3.7
+      - python=3.6
       - conda-forge::allennlp=0.7.2
       - pip=9.0.3
     pip:

--- a/SeqVec/structure/model.yaml
+++ b/SeqVec/structure/model.yaml
@@ -17,7 +17,7 @@ info: # General information about the model
 
 dependencies:
     conda: # install via conda
-      - python=3.7
+      - python=3.6
       - conda-forge::allennlp=0.7.2
       - pip=9.0.3
       - scikit-learn==0.22.2.post1

--- a/SeqVec/structure/model.yaml
+++ b/SeqVec/structure/model.yaml
@@ -17,7 +17,7 @@ info: # General information about the model
 
 dependencies:
     conda: # install via conda
-      - python=3.6
+      - python=3.7
       - conda-forge::allennlp=0.7.2
       - pip=9.0.3
       - scikit-learn==0.22.2.post1

--- a/SiSp/dataloader.yaml
+++ b/SiSp/dataloader.yaml
@@ -25,7 +25,7 @@ dependencies:
   conda:
   - bioconda::pysam
   - bioconda::tabix
-  - python=3.6
+  - python=3.7
   - numpy
   - pandas
 info:

--- a/SiSp/dataloader.yaml
+++ b/SiSp/dataloader.yaml
@@ -23,11 +23,11 @@ args:
 defined_as: dataloader.py::data
 dependencies:
   conda:
-  - bioconda::pysam
-  - bioconda::tabix
+  - bioconda::pysam=0.18.0
+  - bioconda::tabix=1.11
   - python=3.7
-  - numpy
-  - pandas
+  - numpy=1.21.5
+  - pandas=1.3.5
 info:
   authors:
   - email: lara.h.urban@gmail.com

--- a/SiSp/model.yaml
+++ b/SiSp/model.yaml
@@ -11,7 +11,7 @@ args:
 default_dataloader: .
 dependencies:
   conda:
-  - python=3.6
+  - python=3.7
   - numpy=1.17.4
   - pandas=0.24.2
   - pip=20.2.4

--- a/SiSp/model.yaml
+++ b/SiSp/model.yaml
@@ -12,12 +12,12 @@ default_dataloader: .
 dependencies:
   conda:
   - python=3.7
-  - numpy=1.17.4
-  - pandas=0.24.2
+  - numpy=1.21.5
+  - pandas=1.3.5
   - pip=20.2.4
   pip:
-  - keras==2.1.6
-  - tensorflow==1.4.1
+  - keras==2.8.0
+  - tensorflow==2.8.0
   - h5py==2.9.0
 info:
   authors:

--- a/Xpresso/model-template.yaml
+++ b/Xpresso/model-template.yaml
@@ -24,7 +24,7 @@ info: # General information about the model
 
 dependencies:
     conda: # install via conda
-      - python=3.6
+      - python=3.7
       - h5py=2.10
       - numpy=1.19.2
       - pip=20.3.3

--- a/deepTarget/dataloader.yaml
+++ b/deepTarget/dataloader.yaml
@@ -17,12 +17,10 @@ args:
 defined_as: dataloader.py::dataset
 dependencies:
   conda:
-  - biopython>=1.66
-  - scikit-learn>=0.18.2
-  - pandas<=0.23
-  - theano
-  - numpy<=1.12.0
+  - biopython
   pip:
+  - theano
+  - scikit-learn==0.19.2
   - keras==0.3.3
 info:
   authors:

--- a/deepTarget/model.yaml
+++ b/deepTarget/model.yaml
@@ -15,8 +15,8 @@ defined_as: model.Model
 dependencies:
   conda:
   - python=3.7
-  - theano=1.0.4
-  - numpy=1.11.3
+  - theano
+  - numpy
   - pip=21.0.1
   pip:
   - keras==0.3.3

--- a/deepTarget/model.yaml
+++ b/deepTarget/model.yaml
@@ -15,10 +15,9 @@ defined_as: model.Model
 dependencies:
   conda:
   - python=3.7
-  - theano
-  - numpy
   - pip=21.0.1
   pip:
+  - theano
   - keras==0.3.3
 info:
   authors:

--- a/deepTarget/model.yaml
+++ b/deepTarget/model.yaml
@@ -45,3 +45,9 @@ schema:
   targets:
     doc: Prediction probability
     shape: (1,)
+
+test:
+  expect:
+    url: https://zenodo.org/record/6492309/files/deepTarget.predictions.h5?download=1
+    md5: 13194cc73986706d656d771d74e4a60a
+  precision_decimal: 5

--- a/deepTarget/model.yaml
+++ b/deepTarget/model.yaml
@@ -14,7 +14,7 @@ args:
 defined_as: model.Model
 dependencies:
   conda:
-  - python=3.6.13
+  - python=3.7
   - theano=1.0.4
   - numpy=1.11.3
   - pip=21.0.1

--- a/deepTarget/model.yaml
+++ b/deepTarget/model.yaml
@@ -50,4 +50,4 @@ test:
   expect:
     url: https://zenodo.org/record/6492309/files/deepTarget.predictions.h5?download=1
     md5: 13194cc73986706d656d771d74e4a60a
-  precision_decimal: 5
+  precision_decimal: 4

--- a/epidermal_basset/encode-roadmap.basset.clf.testfold-0/model.yaml
+++ b/epidermal_basset/encode-roadmap.basset.clf.testfold-0/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/encode-roadmap.basset.clf.testfold-0/model.yaml
+++ b/epidermal_basset/encode-roadmap.basset.clf.testfold-0/model.yaml
@@ -38,11 +38,11 @@ info: # General information about the model
 dependencies:
   conda: # install via conda
     - python=3.7
-    - h5py=2.10.0
+    - h5py
     - pip=20.2.4
   pip:   # install via pip
     - kipoiseq
-    - tensorflow==1.8
+    - tensorflow
     
 schema:  # Model schema. The schema defintion is essential for kipoi plug-ins to work.
     inputs:  # input = single numpy array

--- a/epidermal_basset/encode-roadmap.basset.clf.testfold-1/model.yaml
+++ b/epidermal_basset/encode-roadmap.basset.clf.testfold-1/model.yaml
@@ -38,11 +38,11 @@ info: # General information about the model
 dependencies:
   conda: # install via conda
     - python=3.7
-    - h5py=2.10.0
+    - h5py
     - pip=20.2.4
   pip:   # install via pip
     - kipoiseq
-    - tensorflow==1.8
+    - tensorflow
 
 schema:  # Model schema. The schema defintion is essential for kipoi plug-ins to work.
     inputs:  # input = single numpy array

--- a/epidermal_basset/encode-roadmap.basset.clf.testfold-1/model.yaml
+++ b/epidermal_basset/encode-roadmap.basset.clf.testfold-1/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/encode-roadmap.basset.clf.testfold-2/model.yaml
+++ b/epidermal_basset/encode-roadmap.basset.clf.testfold-2/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/encode-roadmap.basset.clf.testfold-3/model.yaml
+++ b/epidermal_basset/encode-roadmap.basset.clf.testfold-3/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/encode-roadmap.basset.clf.testfold-4/model.yaml
+++ b/epidermal_basset/encode-roadmap.basset.clf.testfold-4/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/encode-roadmap.basset.clf.testfold-5/model.yaml
+++ b/epidermal_basset/encode-roadmap.basset.clf.testfold-5/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/encode-roadmap.basset.clf.testfold-6/model.yaml
+++ b/epidermal_basset/encode-roadmap.basset.clf.testfold-6/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/encode-roadmap.basset.clf.testfold-7/model.yaml
+++ b/epidermal_basset/encode-roadmap.basset.clf.testfold-7/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/encode-roadmap.basset.clf.testfold-8/model.yaml
+++ b/epidermal_basset/encode-roadmap.basset.clf.testfold-8/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/encode-roadmap.basset.clf.testfold-9/model.yaml
+++ b/epidermal_basset/encode-roadmap.basset.clf.testfold-9/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/ggr.basset.clf.pretrained.folds.testfold-0/model.yaml
+++ b/epidermal_basset/ggr.basset.clf.pretrained.folds.testfold-0/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/ggr.basset.clf.pretrained.folds.testfold-0/model.yaml
+++ b/epidermal_basset/ggr.basset.clf.pretrained.folds.testfold-0/model.yaml
@@ -38,11 +38,11 @@ info: # General information about the model
 dependencies:
   conda: # install via conda
     - python=3.7
-    - h5py=2.10.0
+    - h5py
     - pip=20.2.4
   pip:   # install via pip
     - kipoiseq
-    - tensorflow==1.8
+    - tensorflow
     
 schema:  # Model schema. The schema defintion is essential for kipoi plug-ins to work.
     inputs:  # input = single numpy array

--- a/epidermal_basset/ggr.basset.clf.pretrained.folds.testfold-1/model.yaml
+++ b/epidermal_basset/ggr.basset.clf.pretrained.folds.testfold-1/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/ggr.basset.clf.pretrained.folds.testfold-2/model.yaml
+++ b/epidermal_basset/ggr.basset.clf.pretrained.folds.testfold-2/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/ggr.basset.clf.pretrained.folds.testfold-3/model.yaml
+++ b/epidermal_basset/ggr.basset.clf.pretrained.folds.testfold-3/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/ggr.basset.clf.pretrained.folds.testfold-4/model.yaml
+++ b/epidermal_basset/ggr.basset.clf.pretrained.folds.testfold-4/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/ggr.basset.clf.pretrained.folds.testfold-5/model.yaml
+++ b/epidermal_basset/ggr.basset.clf.pretrained.folds.testfold-5/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/ggr.basset.clf.pretrained.folds.testfold-6/model.yaml
+++ b/epidermal_basset/ggr.basset.clf.pretrained.folds.testfold-6/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/ggr.basset.clf.pretrained.folds.testfold-7/model.yaml
+++ b/epidermal_basset/ggr.basset.clf.pretrained.folds.testfold-7/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/ggr.basset.clf.pretrained.folds.testfold-8/model.yaml
+++ b/epidermal_basset/ggr.basset.clf.pretrained.folds.testfold-8/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/ggr.basset.clf.pretrained.folds.testfold-9/model.yaml
+++ b/epidermal_basset/ggr.basset.clf.pretrained.folds.testfold-9/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/ggr.basset.regr.pretrained.folds.testfold-0/model.yaml
+++ b/epidermal_basset/ggr.basset.regr.pretrained.folds.testfold-0/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/ggr.basset.regr.pretrained.folds.testfold-1/model.yaml
+++ b/epidermal_basset/ggr.basset.regr.pretrained.folds.testfold-1/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/ggr.basset.regr.pretrained.folds.testfold-2/model.yaml
+++ b/epidermal_basset/ggr.basset.regr.pretrained.folds.testfold-2/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/ggr.basset.regr.pretrained.folds.testfold-3/model.yaml
+++ b/epidermal_basset/ggr.basset.regr.pretrained.folds.testfold-3/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/ggr.basset.regr.pretrained.folds.testfold-4/model.yaml
+++ b/epidermal_basset/ggr.basset.regr.pretrained.folds.testfold-4/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/ggr.basset.regr.pretrained.folds.testfold-5/model.yaml
+++ b/epidermal_basset/ggr.basset.regr.pretrained.folds.testfold-5/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/ggr.basset.regr.pretrained.folds.testfold-6/model.yaml
+++ b/epidermal_basset/ggr.basset.regr.pretrained.folds.testfold-6/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/ggr.basset.regr.pretrained.folds.testfold-7/model.yaml
+++ b/epidermal_basset/ggr.basset.regr.pretrained.folds.testfold-7/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/ggr.basset.regr.pretrained.folds.testfold-8/model.yaml
+++ b/epidermal_basset/ggr.basset.regr.pretrained.folds.testfold-8/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/ggr.basset.regr.pretrained.folds.testfold-9/model.yaml
+++ b/epidermal_basset/ggr.basset.regr.pretrained.folds.testfold-9/model.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/epidermal_basset/model-template.yaml
+++ b/epidermal_basset/model-template.yaml
@@ -37,7 +37,7 @@ info: # General information about the model
 
 dependencies:
   conda: # install via conda
-    - python=3.6
+    - python=3.7
     - h5py=2.10.0
     - pip=20.2.4
   pip:   # install via pip

--- a/extended_coda/model.yaml
+++ b/extended_coda/model.yaml
@@ -45,3 +45,9 @@ schema:
       shape: (None, 1)
       special_type: bigwig
 type: keras
+
+test:
+  expect:
+    url: https://zenodo.org/record/6492281/files/extended_coda.predictions.h5?download=1
+    md5: bdb294f95a511c1766e65803e6fb03d6
+      

--- a/extended_coda/model.yaml
+++ b/extended_coda/model.yaml
@@ -9,7 +9,7 @@ args:
   image_dim_ordering: tf
 dependencies:
   conda:
-  - python=3.6
+  - python=3.7
   - pip=20.3.3
   - pysam=0.15.3
   pip:

--- a/labranchor/dataloader.yaml
+++ b/labranchor/dataloader.yaml
@@ -15,7 +15,7 @@ args:
 defined_as: dataloader.py::BranchPointDataset
 dependencies:
   conda:
-  - python=3.6
+  - python=3.7
   pip:
   - pysam
   - numpy

--- a/labranchor/dataloader.yaml
+++ b/labranchor/dataloader.yaml
@@ -16,8 +16,9 @@ defined_as: dataloader.py::BranchPointDataset
 dependencies:
   conda:
   - python=3.7
+  - bioconda::pysam=0.15.3
+  - pip=20.2.4
   pip:
-  - pysam
   - numpy
 info:
   authors:

--- a/labranchor/model.yaml
+++ b/labranchor/model.yaml
@@ -12,7 +12,7 @@ dependencies:
   - python=3.7
   - bioconda::pysam=0.15.3
   pip:
-  - tensorflow
+  - tensorflow==1.15
   - keras==2.1.6
   - h5py==2.9.0
   - kipoi==0.6.35

--- a/labranchor/model.yaml
+++ b/labranchor/model.yaml
@@ -9,7 +9,7 @@ default_dataloader: .
 dependencies:
   conda:
   - pip=20.2.4
-  - python=3.6
+  - python=3.7
   - bioconda::pysam=0.15.3
   pip:
   - tensorflow==1.4.1

--- a/labranchor/model.yaml
+++ b/labranchor/model.yaml
@@ -12,7 +12,7 @@ dependencies:
   - python=3.7
   - bioconda::pysam=0.15.3
   pip:
-  - tensorflow==1.4.1
+  - tensorflow
   - keras==2.1.6
   - h5py==2.9.0
   - kipoi==0.6.35

--- a/labranchor/model.yaml
+++ b/labranchor/model.yaml
@@ -15,7 +15,7 @@ dependencies:
   - tensorflow==1.15
   - keras==2.1.6
   - h5py==2.9.0
-  - kipoi==0.6.35
+  - kipoi
 info:
   authors:
   - github: jpaggi

--- a/lsgkm-SVM/model-template.yaml
+++ b/lsgkm-SVM/model-template.yaml
@@ -23,7 +23,7 @@ dependencies:
     conda:
       - bioconda::ls-gkm=0.0.1
       - numpy
-      - python=3.6
+      - python=3.7
       - numpy=1.19.2 
       - pip=20.3.3 
       - pysam=0.15.3

--- a/pwm_HOCOMOCO/model-template.yaml
+++ b/pwm_HOCOMOCO/model-template.yaml
@@ -28,7 +28,7 @@ default_dataloader:
 
 dependencies:
   conda:
-    - python=3.6
+    - python=3.7
     - h5py=2.8.0
     - pip=20.2.4
   pip:

--- a/pwm_HOCOMOCO/model-template.yaml
+++ b/pwm_HOCOMOCO/model-template.yaml
@@ -29,11 +29,11 @@ default_dataloader:
 dependencies:
   conda:
     - python=3.7
-    - h5py=2.8.0
-    - pip=20.2.4
+    - h5py
+    - pip
   pip:
-    - tensorflow<=1.9.0
-    - keras==2.0.4
+    - tensorflow
+    - keras
 schema:
   inputs:
     name: seq

--- a/rbp_eclip/dataloader-template.yaml
+++ b/rbp_eclip/dataloader-template.yaml
@@ -44,7 +44,7 @@ dependencies:
   - bioconda::pybigwig
   - bioconda::pyfaidx
   - bioconda::gtfparse>=1.0.7
-  - python=3.6
+  - python=3.7
   - cython
   - scikit-learn=0.18.1
   - pandas=0.23.4

--- a/rbp_eclip/dataloader-template.yaml
+++ b/rbp_eclip/dataloader-template.yaml
@@ -40,14 +40,14 @@ dependencies:
   conda:
   - bioconda::pybedtools
   - bioconda::pysam=0.15.3
-  - bioconda::genomelake=0.1.4
+  - bioconda::genomelake
   - bioconda::pybigwig
   - bioconda::pyfaidx
   - bioconda::gtfparse>=1.0.7
   - python=3.7
   - cython
-  - scikit-learn=0.18.1
-  - pandas=0.23.4
+  - scikit-learn<1.*
+  - pandas
   - pip=20.3.3
   pip:
   - concise>=0.6.6

--- a/rbp_eclip/dataloader-template.yaml
+++ b/rbp_eclip/dataloader-template.yaml
@@ -43,15 +43,13 @@ dependencies:
   - bioconda::genomelake
   - bioconda::pybigwig
   - bioconda::pyfaidx
-  - bioconda::gtfparse>=1.0.7
   - python=3.7
   - cython
-  - pandas=0.23.4
   - pip=20.3.3
   pip:
+  - gtfparse>=1.0.7
   - concise>=0.6.6
-  - numpy>=1.13.3
-  - scikit-learn==0.19.0
+  - scikit-learn==0.19.2
 
 info:
   authors:

--- a/rbp_eclip/model-template.yaml
+++ b/rbp_eclip/model-template.yaml
@@ -32,10 +32,9 @@ dependencies:
         - pip=20.3.3
     pip:
         - concise
-        - tensorflow
+        - tensorflow==1.15
         - keras==2.1.6
-        - numpy
-        - h5py
+        - h5py==2.10.0
 schema:
     inputs:
         seq:

--- a/rbp_eclip/model-template.yaml
+++ b/rbp_eclip/model-template.yaml
@@ -31,12 +31,11 @@ dependencies:
     conda:
         - pip=20.3.3
     pip:
-        - concise==0.6.9
-        - tensorflow==1.4.1
+        - concise
+        - tensorflow
         - keras==2.1.6
-        - numpy==1.17.4
-        - h5py==2.10.0
-
+        - numpy
+        - h5py
 schema:
     inputs:
         seq:

--- a/shared/envs/kipoi-py3-keras1.2.yaml
+++ b/shared/envs/kipoi-py3-keras1.2.yaml
@@ -21,7 +21,7 @@ dependencies:
   - kipoi_interpret
   - kipoi
   - kipoiseq
-  - tensorflow==1.4.1
+  - tensorflow==1.15
   - keras==1.2.2
   - deepcpg==1.0.4
   # other 

--- a/shared/envs/kipoi-py3-keras1.2.yaml
+++ b/shared/envs/kipoi-py3-keras1.2.yaml
@@ -9,7 +9,7 @@ dependencies:
 - bedtools
 - pybedtools
 - pysam
-- python=3.6
+- python=3.7
 - h5py
 - genomelake==0.1.4
 - numpy

--- a/shared/envs/kipoi-py3-keras1.2.yaml
+++ b/shared/envs/kipoi-py3-keras1.2.yaml
@@ -4,19 +4,18 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-- pyvcf
-- cyvcf2
-- bedtools
-- pybedtools
-- pysam
+- cyvcf2=0.11.6
+- bedtools=2.30.0
+- pybedtools=0.8.1
+- pysam=0.15.3
 - python=3.7
-- h5py
 - genomelake==0.1.4
 - numpy
 - pandas
-- cython
+- cython=0.29.28
 - pip=21.3.1
 - pip:
+  - pyvcf==0.4.3
   - kipoi_veff
   - kipoi_interpret
   - kipoi
@@ -24,5 +23,4 @@ dependencies:
   - tensorflow==1.15
   - keras==1.2.2
   - deepcpg==1.0.4
-  # other 
-  - ipykernel
+  - h5py==3.6.0

--- a/shared/envs/kipoi-py3-keras2.yaml
+++ b/shared/envs/kipoi-py3-keras2.yaml
@@ -1,46 +1,46 @@
 name: kipoi-py3-keras2
 channels:
+- pytorch
 - bioconda
 - conda-forge
-- pytorch
 - defaults
 dependencies:
 - python=3.7
-- pip=21.3.1
-- pyvcf
-- cyvcf2
-- bedtools
-- pybedtools
-- pysam
-- genomelake==0.1.4
+- pip
 - cython
+- pyvcf
+- ls-gkm=0.0.1
 - h5py
-- pytorch-cpu>=0.2.0
-- pandas
+- pytorch
 - bedtools
 - maxentpy
 - tabix
-- ls-gkm=0.0.1
-- pybigwig
-- gtfparse>=1.0.7
-- scikit-learn==0.18.1
+- scikit-learn=0.19.2
+- bedtools
+- genomelake
 - pip:
+  - pandas 
+  - pybigwig
+  - gtfparse>=1.0.7
+  # - pyvcf
+  - cyvcf2
+  - pybedtools
+  - pysam
   - kipoi_veff
   - kipoi_interpret
   - kipoi
   - kipoiseq
-  - tensorflow==1.4.1
+  - tensorflow==2.1.4
   - keras==2.1.6
   - gffutils
   - pyfaidx
   # - scikit-learn
-  - pyvcf
   - intervaltree
   - joblib
   - sklearn-pandas
   - tqdm
   # - mmsplice
-  - numpy==1.17.4
+  - numpy
   - concise>=0.6.6
   # other 
   - ipykernel

--- a/shared/envs/kipoi-py3-keras2.yaml
+++ b/shared/envs/kipoi-py3-keras2.yaml
@@ -3,6 +3,7 @@ channels:
 - pytorch
 - bioconda
 - conda-forge
+- defaults
 dependencies:
 - python=3.7
 - pip=21.2.2

--- a/shared/envs/kipoi-py3-keras2.yaml
+++ b/shared/envs/kipoi-py3-keras2.yaml
@@ -3,44 +3,42 @@ channels:
 - pytorch
 - bioconda
 - conda-forge
-- defaults
 dependencies:
 - python=3.7
-- pip
-- cython
-- pyvcf
+- pip=21.2.2
+- cython=0.29.28
 - ls-gkm=0.0.1
-- h5py
-- pytorch
-- bedtools
-- maxentpy
-- tabix
-- scikit-learn=0.19.2
-- bedtools
-- genomelake
+- h5py=2.10.0
+- pytorch=1.11.0
+- bedtools=2.30.0
+- maxentpy=0.0.1
+- tabix=1.11
+- bedtools=2.30.0
+- genomelake=0.1.4
+- pybigwig=0.3.17
+- pandas=1.3.5
+- cyvcf2=0.11.6
+- pybedtools=0.8.1
+- pysam=0.15.3
+- joblib=1.1.0
 - pip:
-  - pandas 
-  - pybigwig
+  - scikit-learn==0.19.2
   - gtfparse>=1.0.7
-  # - pyvcf
-  - cyvcf2
-  - pybedtools
-  - pysam
+  - pyvcf==0.4.3
   - kipoi_veff
   - kipoi_interpret
   - kipoi
   - kipoiseq
-  - tensorflow==2.1.4
+  - tensorflow==1.15
   - keras==2.1.6
-  - gffutils
-  - pyfaidx
+  - gffutils==0.10.1
+  - pyfaidx==0.6.4
   # - scikit-learn
-  - intervaltree
-  - joblib
-  - sklearn-pandas
-  - tqdm
+  - intervaltree==2.1.0
+  # - sklearn-pandas
+  - tqdm==4.64.0
   # - mmsplice
   - numpy
   - concise>=0.6.6
   # other 
-  - ipykernel
+  - ipykernel==6.13.0

--- a/shared/envs/kipoi-py3-keras2.yaml
+++ b/shared/envs/kipoi-py3-keras2.yaml
@@ -5,7 +5,7 @@ channels:
 - pytorch
 - defaults
 dependencies:
-- python=3.6
+- python=3.7
 - pip=21.3.1
 - pyvcf
 - cyvcf2


### PR DESCRIPTION
Most of the model groups were comfortable with python 3.7. Few things to note - 

1. KipoiSplice and SeqVec were left as is because I could not make them work with python=3.7.
2. I made a new [release](https://github.com/kipoi/models/releases/tag/v2022-04-26) out of master branch. This is the last release with python=3.6 dependency. After merging this I will continue to monitor nightly tests and re-containerize. In doubt just revert this pull request and everything should go back as is.
3. I also made some changes to the test config by adding shard parameters to test_common_env.
4. Finally, I have added test predictions for the following model groups - AttentiveChrome, BPNet-OSKN, DeepMEL, deepTarget, extended_coda, Framepool and MPRA-DragoNN. These predictions were produced on my laptop (osx) with python 3.6 dependencies and uploaded to zenodo. The only model groups which are missing test predictions are - `Basenji, DeepFlyBrain, MMSplice, Xpresso and epidermal_basset.`