### PR TITLE
Add test predictions for model groups

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,12 @@ jobs:
       - *sync
 
   # test only the newly added model
-  test_new_models: 
+  test_new_models:
+    parameters:
+      num_of_shards: 
+        type: integer
+      shard_id:
+        type: integer
     <<: *defaults
     steps:
       - checkout
@@ -102,12 +107,17 @@ jobs:
       - *setup
       - run:
           name: run tests
-          command: kipoi test-source kipoi --git-range master HEAD --verbose
+          command: kipoi test-source kipoi --git-range master HEAD --verbose --num_of_shards << parameters.num_of_shards >> --shard_id << parameters.shard_id >>
           no_output_timeout: 60m
       - *store_artifacts
     
   # test only the newly added model with singularity
   test_new_models_singularity:
+    parameters:
+      num_of_shards: 
+        type: integer
+      shard_id:
+        type: integer
     <<: *defaults
     steps:
       - checkout
@@ -122,7 +132,7 @@ jobs:
       - *setup
       - run:
           name: run tests
-          command: kipoi test-source kipoi --git-range master HEAD --verbose --singularity
+          command: kipoi test-source kipoi --git-range master HEAD --verbose --singularity --num_of_shards << parameters.num_of_shards >> --shard_id << parameters.shard_id >>
       - *store_artifacts
   
   # test all models in the repo
@@ -218,12 +228,20 @@ workflows:
   test-models:
      jobs:
        - test_new_models:
+           matrix:
+            parameters:
+              num_of_shards: [4]
+              shard_id: [0, 1, 2, 3]
            filters:
              branches:
                ignore:
                  - master
                  - test_all
        - test_new_models_singularity:
+           matrix:
+            parameters:
+              num_of_shards: [4]
+              shard_id: [0, 1, 2, 3]
            filters:
              branches:
                ignore:

--- a/APARENT/veff/model.yaml
+++ b/APARENT/veff/model.yaml
@@ -70,3 +70,8 @@ schema:
       shape: (1, )
       doc: >
         Predicts logit difference to reference of having a PolyA cut site for each position in the specified DNA range
+test:
+  expect:
+    url: https://zenodo.org/record/6553313/files/APARENT-veff.predictions.h5?download=1
+    md5: faad23c55571036a3378423e811dba60
+  precision_decimal: 4

--- a/DeepFlyBrain/model.yaml
+++ b/DeepFlyBrain/model.yaml
@@ -41,3 +41,4 @@ test:
   expect:
     url: https://zenodo.org/record/6553263/files/DeepFlyBrain.predictions.h5?download=1
     md5: ca6cd935840a6117c754c715a5904af4
+  precision_decimal: 4

--- a/DeepFlyBrain/model.yaml
+++ b/DeepFlyBrain/model.yaml
@@ -37,3 +37,7 @@ schema:
        name: topic
        shape: (81,)
        doc: Topic Prediction
+test:
+  expect:
+    url: https://zenodo.org/record/6553263/files/DeepFlyBrain.predictions.h5?download=1
+    md5: ca6cd935840a6117c754c715a5904af4

--- a/DeepSTARR/model.yaml
+++ b/DeepSTARR/model.yaml
@@ -45,5 +45,7 @@ schema:
         shape: (2,)
         doc: Developmental and housekeeping enhancer activity
         
-
-
+test:
+    expect:
+        url: https://zenodo.org/record/6553385/files/DeepSTARR.predictions.h5?download=1
+        md5: 7331a9f1c25ce8ecff96fc0640c64a4a

--- a/DeepSTARR/model.yaml
+++ b/DeepSTARR/model.yaml
@@ -49,3 +49,4 @@ test:
     expect:
         url: https://zenodo.org/record/6553385/files/DeepSTARR.predictions.h5?download=1
         md5: 7331a9f1c25ce8ecff96fc0640c64a4a
+    precision_decimal: 4

--- a/Xpresso/model-template.yaml
+++ b/Xpresso/model-template.yaml
@@ -48,4 +48,5 @@ test:
     expect: 
       url: https://zenodo.org/record/6553345/files/Xpresso-{{ model }}.predictions.h5?download=1
       md5: d7f0a2a8665a755b2b637389b60b373a
+    precision_decimal: 4
 {% endif %}

--- a/Xpresso/model-template.yaml
+++ b/Xpresso/model-template.yaml
@@ -42,3 +42,10 @@ schema:  # Model schema. The schema defintion is essential for kipoi plug-ins to
     targets:
         shape: (1,)
         doc: predicted log10(RNA expression level)
+
+{% if model == 'human_GM12878' %}
+test:
+    expect: 
+      url: https://zenodo.org/record/6553345/files/Xpresso-{{ model }}.predictions.h5?download=1
+      md5: d7f0a2a8665a755b2b637389b60b373a
+{% endif %}


### PR DESCRIPTION
Adding test predictions for 

1.  DeepFlyBrain
2. APARENT/veff
3. Xpresso
4. DeepSTARR

Like before, I have uploaded the prediction.h5 to zenodo.