### PR TITLE
Adding a new shared env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,6 +228,11 @@ workflows:
                ignore:
                  - master
                  - test_all
+       - test_all_models_common_env:
+           matrix:
+             parameters:
+               num_of_shards: [3]
+               shard_id: [0, 1, 2]
 
                       
   test-all-branch:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,12 +228,6 @@ workflows:
                ignore:
                  - master
                  - test_all
-       - test_all_models_common_env:
-           matrix:
-             parameters:
-               num_of_shards: [3]
-               shard_id: [0, 1, 2]
-
                       
   test-all-branch:
      jobs:

--- a/shared/envs/kipoi-py3-keras2-tf1.yaml
+++ b/shared/envs/kipoi-py3-keras2-tf1.yaml
@@ -1,0 +1,45 @@
+name: kipoi-py3-keras2-tf1
+channels:
+- pytorch
+- bioconda
+- conda-forge
+- defaults
+dependencies:
+- python=3.7
+- pip=21.2.2
+- cython=0.29.28
+- ls-gkm=0.0.1
+- h5py=2.10.0
+- pytorch=1.11.0
+- bedtools=2.30.0
+- maxentpy=0.0.1
+- tabix=1.11
+- bedtools=2.30.0
+- genomelake=0.1.4
+- pybigwig=0.3.17
+- pandas=1.3.5
+- cyvcf2=0.11.6
+- pybedtools=0.8.1
+- pysam=0.15.3
+- joblib=1.1.0
+- pip:
+  - scikit-learn==0.19.2
+  - gtfparse>=1.0.7
+  - pyvcf==0.4.3
+  - kipoi_veff
+  - kipoi_interpret
+  - kipoi
+  - kipoiseq
+  - tensorflow==1.15
+  - keras==2.1.6
+  - gffutils==0.10.1
+  - pyfaidx==0.6.4
+  # - scikit-learn
+  - intervaltree==2.1.0
+  # - sklearn-pandas
+  - tqdm==4.64.0
+  # - mmsplice
+  - numpy
+  - concise>=0.6.6
+  # other 
+  - ipykernel==6.13.0

--- a/shared/envs/kipoi-py3-keras2-tf2.yaml
+++ b/shared/envs/kipoi-py3-keras2-tf2.yaml
@@ -1,4 +1,4 @@
-name: kipoi-py3-keras2
+name: kipoi-py3-keras2-tf2
 channels:
 - pytorch
 - bioconda

--- a/shared/envs/models.yaml
+++ b/shared/envs/models.yaml
@@ -6,7 +6,12 @@ kipoi-py3-keras1.2:
 - CpGenie
 - DeepCpG_DNA
 - Divergent421
-kipoi-py3-keras2:
+kipoi-py3-keras2-tf1:
+- lsgkm-SVM
+- FactorNet
+- DeepBind
+- Basenji
+kipoi-py3-keras2-tf2:
 - Basset
 - DeepSEA/variantEffects
 - DeepSEA/predict


### PR DESCRIPTION
I have divided sharedpy3keras2 into two environments -

1. sharepy3keras2tf1 - For all models which uses tensorflow 1 and keras 2
2. sharepy3keras2tf2 - For all models which uses tensorflow 2 and keras 2

sharepy3keras2tf2 is necessary now that some of the models are upgraded to use python 3.8. The models that I removed in #314 from sharedpy3keras2 now are part of sharepy3keras2tf1 and the remaining are under sharepy3keras2tf2. sharedpy3keras1.2 remains unchanged. 

#TODO: Containers need to be updated 