### PR TITLE
 Fixing issues with triggering sync-containers workflow of kipoi-containers repo from this repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,12 +73,7 @@ variables:
   sync: &sync
     run:
       name: Sync kipoi models and containers repo
-      command: |
-        curl -X POST https://api.github.com/repos/kipoi/kipoi-containers/dispatches \
-        -H 'Accept: application/vnd.github.v3+json' \
-        -u $SYNC_TOKEN \
-        --data '{"event_type": "sync"}'
-
+      command: curl -X POST -H "Accept:application/vnd.github.v3+json" -H "Authorization:token $SYNC_TOKEN" https://api.github.com/repos/kipoi/kipoi-containers/dispatches -d '{"event_type":"sync"}'
 
 jobs:
   sync_containers:


### PR DESCRIPTION
Github has changed its repository dispatch event url - see [here](https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event). Needed to update the CURL statement. However, I somehow could not make circleci parse the yaml with line break.