### PR TITLE
Workaround for KipoiSplice issue

### DIFF
--- a/KipoiSplice/4/dataloader.yaml
+++ b/KipoiSplice/4/dataloader.yaml
@@ -35,6 +35,7 @@ dependencies:
   - h5py
   - numpy
   - python=3.5
+  - attrs=17.4.0
   pip:
   - pyvcf
   - intervaltree
@@ -48,7 +49,6 @@ dependencies:
   - tensorflow>=1.0.0
   - keras==2.2.4
   - protobuf==3.19.4
-  - attrs==21.4.0
 info:
   authors:
   - github: avsecz

--- a/KipoiSplice/4/dataloader.yaml
+++ b/KipoiSplice/4/dataloader.yaml
@@ -48,6 +48,7 @@ dependencies:
   - tensorflow>=1.0.0
   - keras==2.2.4
   - protobuf==3.19.4
+  - attrs==21.4.0
 info:
   authors:
   - github: avsecz

--- a/KipoiSplice/4cons/dataloader.yaml
+++ b/KipoiSplice/4cons/dataloader.yaml
@@ -38,6 +38,7 @@ dependencies:
   - pandas
   - numpy
   - h5py
+  - attrs=17.4.0
   - python=3.5
   pip:
   - pyvcf
@@ -52,7 +53,6 @@ dependencies:
   - tensorflow>=1.0.0
   - keras==2.2.4
   - protobuf==3.19.4
-  - attrs==21.4.0
 info:
   authors:
   - github: avsecz

--- a/KipoiSplice/4cons/dataloader.yaml
+++ b/KipoiSplice/4cons/dataloader.yaml
@@ -52,6 +52,7 @@ dependencies:
   - tensorflow>=1.0.0
   - keras==2.2.4
   - protobuf==3.19.4
+  - attrs==21.4.0
 info:
   authors:
   - github: avsecz


### PR DESCRIPTION
The first set of errors with KipoiSplice originated from the problem with attrs as specified [here](https://github.com/kipoi/kipoi/pull/687). KipoiSplice uses an older version of kipoi so it will not benefit from the new version release. I thought manually pinning attrs in dataloader.yaml would be enough but circleci does not seem to like this. Installation of the conda environments got stuck at random places in 3 trials. It could be temporary or it could be due to the fact that kipoisplice uses python 3.5 and as a result older versions of packages. I am adding a workaround by adding an empty test_subset.txt. In that way KipoiSplice will not be tested as part of ci but there are docker and singularity containers available. I will shortly add an issue. 